### PR TITLE
Updates to Alum Directory

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -5,6 +5,7 @@ import { Container, Segment, Message , Button} from 'semantic-ui-react';
 import { Route, BrowserRouter as Router, Switch, Redirect } from 'react-router-dom'
 import Header from './components/Header';
 import LoginForm from './components/LoginForm';
+import AlumniDirectory from './components/AlumniDirectory'
 import Register from './screens/Register';
 import { makeCall } from "./apis";
 import Navbar from './components/Navbar'
@@ -217,7 +218,8 @@ class App extends Component {
                           navItems={alumniNavBarItems()}
                           activeItem={'alumniDirectory'}
                       />
-                      <div> Alumni Directory! </div>
+
+                      <div> <AlumniDirectory/> </div>
                   </> :
                   <Redirect to={"/login"}/>
               }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -219,7 +219,7 @@ class App extends Component {
                           activeItem={'alumniDirectory'}
                       />
 
-                      <div> <AlumniDirectory/> </div>
+                      <div> <AlumniDirectory isAlumniView={true}/> </div>
                   </> :
                   <Redirect to={"/login"}/>
               }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -219,7 +219,7 @@ class App extends Component {
                           activeItem={'alumniDirectory'}
                       />
 
-                      <AlumniDirectory isAlumniView={false}/>
+                      <AlumniDirectory isAlumniView={true}/>
                   </> :
                   <Redirect to={"/login"}/>
               }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -219,7 +219,7 @@ class App extends Component {
                           activeItem={'alumniDirectory'}
                       />
 
-                      <div> <AlumniDirectory isAlumniView={true}/> </div>
+                      <AlumniDirectory isAlumniView={false}/>
                   </> :
                   <Redirect to={"/login"}/>
               }

--- a/client/src/components/AlumniDirectory.js
+++ b/client/src/components/AlumniDirectory.js
@@ -89,14 +89,6 @@ export default class AlumniDirectory extends Component {
         console.log(entries)
         let profiles=[]
         for (let post of entries) {
-            var requestButton;
-            if (('zoomLink' in post) && !this.props.isAlumniView) {
-                requestButton = <Button primary>Make Request</Button>
-            } else if (!this.props.isAlumniView){
-                requestButton = <Button disabled>Make Request</Button>
-            } else {
-                requestButton = null;
-            }
             profiles.push(
                 <Grid.Row columns={2}>
                     <Grid.Column width={4}>
@@ -128,7 +120,7 @@ export default class AlumniDirectory extends Component {
                                 <Card.Description>Company: {post.company}</Card.Description>
                                 <br />
                             </Card.Content>
-                            {requestButton}
+                            {requestVisible(this.props.isAlumniView, post)}
                         </Card>
                     </Grid.Column>
                 </Grid.Row>
@@ -184,4 +176,16 @@ function pageGenerator(profiles, pageSize, activePage) {
         display.push(profiles[(activePage - 1) * pageSize + i])
     }
     return display
+}
+
+function requestVisible(isAlumniView, post) {
+    var requestButton;
+            if (('zoomLink' in post) && !isAlumniView) {
+                requestButton = <Button primary>Make Request</Button>
+            } else if (!isAlumniView){
+                requestButton = <Button disabled>Make Request</Button>
+            } else {
+                requestButton = null;
+            }
+    return requestButton
 }

--- a/client/src/components/AlumniDirectory.js
+++ b/client/src/components/AlumniDirectory.js
@@ -2,6 +2,8 @@ import React, { Component } from 'react';
 import { Card, Image, Search, Pagination, Grid, Segment, Button, Dropdown } from 'semantic-ui-react'
 import { makeCall } from '../apis';
 
+var yearOptions =[]
+
 const searchOptions = [
     {
         key: 'All Fields',
@@ -53,7 +55,8 @@ export default class AlumniDirectory extends Component {
         pageSize: 3,
         totalPages: Math.ceil(0/3),
         entries:[],
-        filter: 'all'
+        filter: 'all',
+        year: Number
     }
 
     componentWillMount() {
@@ -74,8 +77,8 @@ export default class AlumniDirectory extends Component {
     handleSearchChange = (e, { value }) => {
         this.setState({ value })
     }
-    handleDropdownChange = (e, { value }) => {
-        this.setState({ filter: value })
+    handleDropdownChange = (e, { name, value }) => {
+        this.setState({ [name]: value })
     }
 
     render(){
@@ -86,9 +89,17 @@ export default class AlumniDirectory extends Component {
             entries,
             filter
         } = this.state
-        console.log(entries)
+
         let profiles=[]
+        let gradYears=[]
         for (let post of entries) {
+            if(!gradYears.find(year => year['value'] === post.gradYear)) {
+                gradYears.push({
+                    key: post.gradYear,
+                    text: post.gradYear,
+                    value: post.gradYear
+                });
+            }
             profiles.push(
                 <Grid.Row columns={2}>
                     <Grid.Column width={4}>
@@ -126,13 +137,14 @@ export default class AlumniDirectory extends Component {
                 </Grid.Row>
             )
         }
+        gradYears.sort()
 
-        return (
-            
-            <Grid divided="vertically">
-                <p>{filter}</p>
+        let searchRow;
+        //Search Area
+        if (filter !== 'gradYear') {
+            searchRow = (
                 <Grid.Row columns={2}>
-                    <Grid.Column>
+                <Grid.Column>
                         <Search
                             open={false}
                             showNoResults={false}
@@ -140,17 +152,51 @@ export default class AlumniDirectory extends Component {
                             input={{fluid: true}}
                             placeholder={"Search"}
                         />
-                    </Grid.Column>
-                    <Grid.Column>
-                        <Dropdown
-                            placeholder='Search By:'
+                </Grid.Column>
+                <Grid.Column>
+                    <Dropdown
+                        placeholder='Search By:'
+                        floating
+                        selection
+                        options={searchOptions}
+                        name='filter'
+                        onChange={this.handleDropdownChange}
+                    />
+                </Grid.Column>
+                </Grid.Row>
+            )
+        } else {
+            searchRow = (
+                <Grid.Row columns={2}>
+                <Grid.Column>
+                        <Dropdown 
+                            placeholder='Year:'
+                            fluid
                             floating
                             selection
-                            options={searchOptions}
+                            name='year'
+                            options={gradYears}
                             onChange={this.handleDropdownChange}
                         />
-                    </Grid.Column>
+                </Grid.Column>
+                <Grid.Column>
+                    <Dropdown
+                        placeholder='Search By:'
+                        floating
+                        selection
+                        name='filter'
+                        options={searchOptions}
+                        onChange={this.handleDropdownChange}
+                    />
+                </Grid.Column>
                 </Grid.Row>
+            )
+        }
+
+        return ( 
+            <Grid divided="vertically">
+                
+                {searchRow}
                 
                 {pageGenerator(profiles, pageSize, activePage)}
 

--- a/client/src/components/AlumniDirectory.js
+++ b/client/src/components/AlumniDirectory.js
@@ -2,8 +2,7 @@ import React, { Component } from 'react';
 import { Card, Image, Search, Pagination, Grid, Segment, Button, Dropdown } from 'semantic-ui-react'
 import { makeCall } from '../apis';
 
-var yearOptions =[]
-
+// Filter dropdown options
 const searchOptions = [
     {
         key: 'All Fields',
@@ -66,7 +65,6 @@ export default class AlumniDirectory extends Component {
             numEntries: result.alumnus.length
         }))
     }
-
     getEntries() {
         return makeCall(null, '/alumni/all', 'get')
     }
@@ -92,6 +90,8 @@ export default class AlumniDirectory extends Component {
 
         let profiles=[]
         let gradYears=[]
+        
+        /* Card Creation */
         for (let post of entries) {
             if(!gradYears.find(year => year['value'] === post.gradYear)) {
                 gradYears.push({
@@ -137,10 +137,12 @@ export default class AlumniDirectory extends Component {
                 </Grid.Row>
             )
         }
+        /* Card Creation */
+
         gradYears.sort()
 
+        /* Search Area */
         let searchRow;
-        //Search Area
         if (filter !== 'gradYear') {
             searchRow = (
                 <Grid.Row columns={2}>
@@ -192,6 +194,7 @@ export default class AlumniDirectory extends Component {
                 </Grid.Row>
             )
         }
+        /* Search Area */
 
         return ( 
             <Grid divided="vertically">
@@ -216,6 +219,11 @@ export default class AlumniDirectory extends Component {
     }
 }
 
+// Helper Functions
+
+// Args: list of generated alumni cards(jsx objects)
+//       desired page size (int), active page (int)
+// Returns: jsx for the cards to display on the page the user is viewing
 function pageGenerator(profiles, pageSize, activePage) {
     let display=[]
     for (let i = 0; i < pageSize; i++) {
@@ -224,6 +232,8 @@ function pageGenerator(profiles, pageSize, activePage) {
     return display
 }
 
+// Args: isAlumniView (bool), alumni (object)
+// Returns: jsx for the request button (either active, disabled, hidden)
 function requestVisible(isAlumniView, post) {
     var requestButton;
             if (('zoomLink' in post) && !isAlumniView) {

--- a/client/src/components/AlumniDirectory.js
+++ b/client/src/components/AlumniDirectory.js
@@ -60,13 +60,13 @@ export default class AlumniDirectory extends Component {
 
     componentWillMount() {
         this.getEntries().then(result => this.setState({
-            entries: result.alumnus,
-            totalPages: Math.ceil(result.alumnus.length/3),
-            numEntries: result.alumnus.length
-        }).catch(e => console.log(e)))
+            entries: result.alumni,
+            totalPages: Math.ceil(result.alumni.length/3),
+            numEntries: result.alumni.length
+        }))
     }
     async getEntries() {
-        return await makeCall(null, '/alumni/all', 'get')
+        return await makeCall(null, '/alumni/all', 'get').catch(e => console.log(e))
     }
 
     handlePaginationChange = (e, { activePage }) => {

--- a/client/src/components/AlumniDirectory.js
+++ b/client/src/components/AlumniDirectory.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
-import { Card, Image, Search, Pagination, Grid, Segment } from 'semantic-ui-react'
+import { Card, Image, Search, Pagination, Grid, Segment, Button } from 'semantic-ui-react'
+import { makeCall } from '../apis';
 
 /*
 props:
@@ -8,11 +9,24 @@ props:
 export default class AlumniDirectory extends Component {
     state = {
         activePage: 1,
-        numEntries: this.props.entries.length,
+        numEntries: 0,
         isLoading: false,
         value: '',
         pageSize: 3,
-        totalPages: Math.ceil(this.props.entries.length/3)
+        totalPages: Math.ceil(0/3),
+        entries:[]
+    }
+
+    componentWillMount() {
+        this.getEntries().then(result => this.setState({
+            entries: result.alumnus,
+            totalPages: Math.ceil(result.alumnus.length/3),
+            numEntries: result.alumnus.length
+        }))
+    }
+
+    getEntries() {
+        return makeCall(null, '/alumni/all', 'get')
     }
 
     handlePaginationChange = (e, { activePage }) => {
@@ -26,11 +40,18 @@ export default class AlumniDirectory extends Component {
         const {
             totalPages,
             activePage,
-            pageSize
+            pageSize,
+            entries
         } = this.state
-
+        console.log(entries)
         let profiles=[]
-        for (let post of this.props.entries) {
+        for (let post of entries) {
+            var requestButton;
+            if ('zoomLink' in post) {
+                requestButton = <Button primary>Make Request</Button>
+            } else {
+                requestButton = <Button disabled>Make Request</Button>
+            }
             profiles.push(
                 <Grid.Row columns={2}>
                     <Grid.Column width={4}>
@@ -54,6 +75,7 @@ export default class AlumniDirectory extends Component {
                                 <Card.Description>Company: {post.company}</Card.Description>
                                 <br />
                             </Card.Content>
+                            {requestButton}
                         </Card>
                     </Grid.Column>
                 </Grid.Row>

--- a/client/src/components/AlumniDirectory.js
+++ b/client/src/components/AlumniDirectory.js
@@ -52,7 +52,7 @@ export default class AlumniDirectory extends Component {
         isLoading: false,
         value: '',
         pageSize: 3,
-        totalPages: Math.ceil(0/3),
+        totalPages: 0,
         entries:[],
         filter: 'all',
         year: Number
@@ -63,10 +63,10 @@ export default class AlumniDirectory extends Component {
             entries: result.alumnus,
             totalPages: Math.ceil(result.alumnus.length/3),
             numEntries: result.alumnus.length
-        }))
+        }).catch(e => console.log(e)))
     }
-    getEntries() {
-        return makeCall(null, '/alumni/all', 'get')
+    async getEntries() {
+        return await makeCall(null, '/alumni/all', 'get')
     }
 
     handlePaginationChange = (e, { activePage }) => {

--- a/client/src/components/AlumniDirectory.js
+++ b/client/src/components/AlumniDirectory.js
@@ -1,10 +1,48 @@
 import React, { Component } from 'react';
-import { Card, Image, Search, Pagination, Grid, Segment, Button } from 'semantic-ui-react'
+import { Card, Image, Search, Pagination, Grid, Segment, Button, Dropdown } from 'semantic-ui-react'
 import { makeCall } from '../apis';
+
+const searchOptions = [
+    {
+        key: 'All Fields',
+        text: 'All Fields',
+        value: 'all'
+    },
+    {
+        key: 'Location',
+        text: 'Location',
+        value: 'location'
+    },
+    {
+        key: 'College',
+        text: 'College',
+        value: 'college'
+    },
+    {
+        key: 'Profession',
+        text: 'Profession',
+        value: 'profession'
+    },
+    {
+        key: 'Company',
+        text: 'Company',
+        value: 'company'
+    },
+    {
+        key: 'Name',
+        text: 'Name',
+        value: 'name'
+    },
+    {
+        key: 'Graduation Year',
+        text: 'Graduation Year',
+        value: 'gradYear'
+    }
+]
 
 /*
 props:
-- entries: list of alumni profiles
+- isAlumniView: shows book request button if false
 */
 export default class AlumniDirectory extends Component {
     state = {
@@ -14,7 +52,8 @@ export default class AlumniDirectory extends Component {
         value: '',
         pageSize: 3,
         totalPages: Math.ceil(0/3),
-        entries:[]
+        entries:[],
+        filter: 'all'
     }
 
     componentWillMount() {
@@ -35,41 +74,55 @@ export default class AlumniDirectory extends Component {
     handleSearchChange = (e, { value }) => {
         this.setState({ value })
     }
+    handleDropdownChange = (e, { value }) => {
+        this.setState({ filter: value })
+    }
 
     render(){
         const {
             totalPages,
             activePage,
             pageSize,
-            entries
+            entries,
+            filter
         } = this.state
         console.log(entries)
         let profiles=[]
         for (let post of entries) {
             var requestButton;
-            if ('zoomLink' in post) {
+            if (('zoomLink' in post) && !this.props.isAlumniView) {
                 requestButton = <Button primary>Make Request</Button>
-            } else {
+            } else if (!this.props.isAlumniView){
                 requestButton = <Button disabled>Make Request</Button>
+            } else {
+                requestButton = null;
             }
             profiles.push(
                 <Grid.Row columns={2}>
                     <Grid.Column width={4}>
-                        <Card fluid>
                             <Image
+                                size='small'
                                 fluid
                                 centered
                                 rounded
                                 src={post.imageURL}
                             />
-                        </Card>
                     </Grid.Column>
-                    <Grid.Column>
+                    <Grid.Column fluid>
                         <Card fluid>
                             <Card.Content>
-                                <Card.Header>{post.name}</Card.Header>
-                                <Card.Meta>{post.jobTitle}</Card.Meta>
-
+                                <Card.Header>
+                                <Grid>
+                                    <Grid.Row columns={2}>
+                                        <Grid.Column>{post.name}</Grid.Column>
+                                        <Grid.Column textAlign='right'>
+                                          Graduated: {post.gradYear}
+                                        </Grid.Column>
+                                    </Grid.Row>
+                                </Grid>
+                                </Card.Header>
+                                
+                                <Card.Meta>{post.profession}</Card.Meta>
                                 <Card.Description>College: {post.college}</Card.Description>
                                 <Card.Description>Location: {post.location}</Card.Description>
                                 <Card.Description>Company: {post.company}</Card.Description>
@@ -83,16 +136,27 @@ export default class AlumniDirectory extends Component {
         }
 
         return (
+            
             <Grid divided="vertically">
-                <Grid.Row>
+                <p>{filter}</p>
+                <Grid.Row columns={2}>
                     <Grid.Column>
-                            <Search
-                                open={false}
-                                showNoResults={false}
-                                onSearchChange={this.handleSearchChange}
-                                input={{fluid: true}}
-                                placeholder={"Search"}
-                            />
+                        <Search
+                            open={false}
+                            showNoResults={false}
+                            onSearchChange={this.handleSearchChange}
+                            input={{fluid: true}}
+                            placeholder={"Search"}
+                        />
+                    </Grid.Column>
+                    <Grid.Column>
+                        <Dropdown
+                            placeholder='Search By:'
+                            floating
+                            selection
+                            options={searchOptions}
+                            onChange={this.handleDropdownChange}
+                        />
                     </Grid.Column>
                 </Grid.Row>
                 

--- a/server/routes/alumni.js
+++ b/server/routes/alumni.js
@@ -68,4 +68,14 @@ router.post('/', async (req, res, next) => {
     }
 });
 
+router.get('/all', async (req, res, next) => {
+    try {
+        const dbData = await alumniSchema.find()
+        res.json({'alumnus' : dbData});
+    } catch (e) {
+        console.log("Error: util#allAlumni", e);
+        res.status(500).send({'error' : e});
+    }
+});
+
 module.exports = router;

--- a/server/routes/alumni.js
+++ b/server/routes/alumni.js
@@ -71,7 +71,7 @@ router.post('/', async (req, res, next) => {
 router.get('/all', async (req, res, next) => {
     try {
         const dbData = await alumniSchema.find()
-        res.json({'alumnus' : dbData});
+        res.json({'alumni' : dbData});
     } catch (e) {
         console.log("Error: util#allAlumni", e);
         res.status(500).send({'error' : e});


### PR DESCRIPTION
### client/src/App.js
- now imports the alumniDirectory component
- replaced the placeholder with AlumniDirectory - in the Alumni case, passes isAlumniView=true

### client/src/components/AlumniDirectory
- no longer takes entries prop
- instead, takes isAlumniView - this is decides whether we need to show or hide the request button
- global constant searchOptions - holds all fields for search dropdown
- states can no longer be automatically assigned through prop based values
    This has been addressed in two ways:
        - numEntries and totalPages are initialized to 0.
        - ComponentWillMount now calls a function to make an api request, which in resolving the promise sets the state of numEntries, entries and totalPages 
        - it then proceeds to call another function to populate the gradYear and allText states. ComponentWillMount is now asynchronous to allow for this behavior, and will only run once.

new function: async this.search()
- currently returns the number of matching profiles for all queries. Will soon call a helper function to create the needed cards. Pretty cool, right? (Note: this means that profiles will become a state)

When creating profile cards, automatically adds unique graduation years to gradYears
- This enables the population of the dropdown for Graduation Year search 

Added graduation year to profile cards!
requestVisible now manages the visibility of the Make Request button (on, disabled, hidden)
The search row now depends on the current filter state (switches between dropdown and search)

### Routes:
GET: /alumni/all
returns all alumni, similar to /mongoose-util/allAlumni

<img width="1398" alt="Screen Shot 2020-05-20 at 9 14 35 PM" src="https://user-images.githubusercontent.com/54961598/82512779-12156d00-9adf-11ea-8acf-6333b1d5466a.png">

<img width="1308" alt="Screen Shot 2020-05-20 at 9 15 20 PM" src="https://user-images.githubusercontent.com/54961598/82512783-1772b780-9adf-11ea-9df1-ab393e8699da.png">

### async Search behavior
Note that a blank filter field is equivalent to all fields
<img width="1119" alt="Screen Shot 2020-05-21 at 9 17 37 PM" src="https://user-images.githubusercontent.com/54961598/82621321-cf1fcc00-9ba8-11ea-8cc1-4701c59f165c.png">