### PR TITLE
Frontend/alum profile

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -9,7 +9,8 @@ import AlumniDirectory from './components/AlumniDirectory'
 import Register from './screens/Register';
 import { makeCall } from "./apis";
 import Navbar from './components/Navbar'
-import Profile from './components/Profile'
+import AlumniProfile from './components/AlumniProfile'
+import StudentProfile from './components/StudentProfile'
 
 import * as actions from './redux/actions'
 
@@ -241,14 +242,9 @@ class App extends Component {
                           navItems={alumniNavBarItems()}
                           activeItem={'profile'}
                       />
-                      <Profile
+                      <AlumniProfile
                         isViewOnly={false}
-                        imageURL={this.state.userDetails && this.state.userDetails.imageURL}
-                        name={this.props.details && this.props.details.name}
-                        college={this.props.details && this.props.details.college}
-                        location={this.props.details && this.props.details.location}
-                        company={this.props.details && this.props.details.company}
-                        jobTitle={this.props.details && this.props.details.jobTitle}
+                        details={this.state.userDetails}
                       />
                   </> :
                   <Redirect to={"/login"}/>
@@ -321,14 +317,9 @@ class App extends Component {
                           navItems={studentNavBarItems()}
                           activeItem={'profile'}
                       />
-                      <Profile
+                      <StudentProfile
                         isViewOnly={false}
-                        imageURL={this.state.userDetails && this.state.userDetails.imageURL}
-                        name={this.props.details && this.props.details.name}
-                        college={this.props.details && this.props.details.college}
-                        location={this.props.details && this.props.details.location}
-                        company={this.props.details && this.props.details.company}
-                        jobTitle={this.props.details && this.props.details.jobTitle}
+                        details={this.state.userDetails}
                       />
                   </> :
                   <Redirect to={"/login"}/>

--- a/client/src/components/AlumniProfile.js
+++ b/client/src/components/AlumniProfile.js
@@ -11,6 +11,7 @@ props:
     - location: string
     - company: string
     - jobTitle: string
+    - email: string
 - isViewOnly: bool
 */
 export default class AlumniProfile extends Component {

--- a/client/src/components/AlumniProfile.js
+++ b/client/src/components/AlumniProfile.js
@@ -20,7 +20,9 @@ export default class AlumniProfile extends Component {
         const isViewOnly = this.props.isViewOnly;
 
         const linkedInUpdate = (
-            <LinkedInUpdate/>
+            <LinkedInUpdate
+                email={details.email}
+            />
         )
         const imageUpdate = (
             <Button floated="right" basic color="blue">

--- a/client/src/components/AlumniProfile.js
+++ b/client/src/components/AlumniProfile.js
@@ -1,0 +1,66 @@
+import React, { Component } from 'react';
+import { Button, Card, Image } from 'semantic-ui-react';
+import LinkedInUpdate from "./LinkedInUpdate";
+
+/*
+props:
+- details: Object containing:
+    - imageURL: string
+    - name: string
+    - college: string
+    - location: string
+    - company: string
+    - jobTitle: string
+- isViewOnly: bool
+*/
+export default class AlumniProfile extends Component {
+    render(){
+        const details = this.props.details;
+        const isViewOnly = this.props.isViewOnly;
+
+        const linkedInUpdate = (
+            <LinkedInUpdate/>
+        )
+        const imageUpdate = (
+            <Button floated="right" basic color="blue">
+                Update Image
+            </Button>
+        )
+        var canUpdate;
+
+        if (!isViewOnly) {
+            canUpdate = (
+                <Card.Content extra>
+                    {linkedInUpdate}
+                    {imageUpdate}
+                </Card.Content>
+            )
+        } else {
+            canUpdate = <div />
+        }
+
+        return (
+            <div>
+            <Card fluid>
+                <Image 
+                    centered
+                    rounded
+                    size="medium"
+                    src={details.imageURL}
+                />
+                <Card.Content>
+                    <Card.Header>{details.name || 'Unavailable'}</Card.Header>
+                    <Card.Meta>{details.profession || 'Unavailable'}</Card.Meta>
+
+                    <Card.Description>College: {details.college || 'Unavailable'}</Card.Description>
+                    <Card.Description>Location: {details.location || 'Unavailable'}</Card.Description>
+                    <Card.Description>Company: {details.company || 'Unavailable'}</Card.Description>
+                    
+                </Card.Content>
+                {canUpdate}
+            </Card>
+            <div padding-top="10px" />
+            </div>
+        )
+    }
+}

--- a/client/src/components/StudentProfile.js
+++ b/client/src/components/StudentProfile.js
@@ -7,10 +7,8 @@ props:
 - details: Object containing:
     - imageURL: string
     - name: string
-    - college: string
-    - location: string
-    - company: string
-    - jobTitle: string
+    - grade: string
+    - email: string
 - isViewOnly: bool
 */
 export default class StudentProfile extends Component {

--- a/client/src/components/StudentProfile.js
+++ b/client/src/components/StudentProfile.js
@@ -17,7 +17,9 @@ export default class StudentProfile extends Component {
         const isViewOnly = this.props.isViewOnly;
 
         const linkedInUpdate = (
-            <LinkedInUpdate/>
+            <LinkedInUpdate
+                email={details.email}
+            />
         )
         const imageUpdate = (
             <Button floated="right" basic color="blue">

--- a/client/src/components/StudentProfile.js
+++ b/client/src/components/StudentProfile.js
@@ -4,22 +4,18 @@ import LinkedInUpdate from "./LinkedInUpdate";
 
 /*
 props:
-- imageURL: string
-- name: string
-- college: string
-- location: string
-- company: string
-- jobTitle: string
+- details: Object containing:
+    - imageURL: string
+    - name: string
+    - college: string
+    - location: string
+    - company: string
+    - jobTitle: string
 - isViewOnly: bool
 */
-export default class Profile extends Component {
+export default class StudentProfile extends Component {
     render(){
-        const imageURL = this.props.imageURL;
-        const name = this.props.name;
-        const college = this.props.college;
-        const location = this.props.location;
-        const company = this.props.company;
-        const jobTitle = this.props.jobTitle;
+        const details = this.props.details;
         const isViewOnly = this.props.isViewOnly;
 
         const linkedInUpdate = (
@@ -50,16 +46,12 @@ export default class Profile extends Component {
                     centered
                     rounded
                     size="medium"
-                    src={imageURL}
+                    src={details.imageURL}
                 />
                 <Card.Content>
-                    <Card.Header>{name || 'Unavailable'}</Card.Header>
-                    <Card.Meta>{jobTitle || 'Unavailable'}</Card.Meta>
+                    <Card.Header>{details.name || 'Unavailable'}</Card.Header>
 
-                    <Card.Description>College: {college || 'Unavailable'}</Card.Description>
-                    <Card.Description>Location: {location || 'Unavailable'}</Card.Description>
-                    <Card.Description>Company: {company || 'Unavailable'}</Card.Description>
-                    
+                    <Card.Description>Grade: {details.grade || 'Unavailable'}</Card.Description>
                 </Card.Content>
                 {canUpdate}
             </Card>

--- a/server/routes/utilMongoose.js
+++ b/server/routes/utilMongoose.js
@@ -105,6 +105,7 @@ const createStudent = async (_email, _name, _picLink) => {
             grade: grade,
             //requests: [{type: Schema.Types.ObjectId, ref: 'requestSchema'}]
             //issuesLiked: [{type: Schema.Types.ObjectId, ref: 'issueSchema'}]
+            imageURL: picLink
         }
     )
     const user_instance = new userSchema(


### PR DESCRIPTION
Backend:
/util/seed/ now gives students an imageURL

Frontend:
Profile now renamed AlumniProfile
StudentProfile created - students don't have much information to display, so this looks a little bare:
<img width="991" alt="Screen Shot 2020-05-25 at 1 05 46 PM" src="https://user-images.githubusercontent.com/54961598/82832222-8148e380-9e88-11ea-8c95-566b9b1ad1fe.png">

App.js now uses the renamed components, and passes in only two props (the profile and isViewOnly)