### PR TITLE
Alumni can add topics they want to consult and update their zoom link

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -149,6 +149,7 @@ class App extends Component {
     this.liftPayload = this.liftPayload.bind(this);
     this.renderScreens = this.renderScreens.bind(this);
     this.renderLoggedInRoutes = this.renderLoggedInRoutes.bind(this);
+    this.refreshProfile = this.refreshProfile.bind(this);
   }
 
   async componentWillMount() {
@@ -187,6 +188,12 @@ class App extends Component {
         });
         console.log("Error: App#componentDidMount", e)
     }
+  }
+
+  async refreshProfile(role, id) {
+    this.setState({
+      userDetails: await this.fetchProfile(role, id)
+    })
   }
 
   async fetchProfile(role, id) {
@@ -247,6 +254,7 @@ class App extends Component {
                       <AlumniProfile
                         isViewOnly={false}
                         details={this.state.userDetails}
+                        refreshProfile={this.refreshProfile}
                       />
                   </> :
                   <Redirect to={"/login"}/>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -192,9 +192,9 @@ class App extends Component {
   async fetchProfile(role, id) {
     let result;
     if (role === 'STUDENT') {
-      result = await makeCall({}, ('/student/'+id), 'get')
+      result = await makeCall({}, ('/student/one/'+id), 'get')
     } else {
-      result = await makeCall({}, ('/alumni/'+id), 'get')
+      result = await makeCall({}, ('/alumni/one/'+id), 'get')
     }
     return result.result
   }

--- a/client/src/components/AlumniProfile.js
+++ b/client/src/components/AlumniProfile.js
@@ -5,6 +5,8 @@ import TimePreferencesModal from './TimePreferencesModal';
 import TopicPreferencesModal from './TopicPreferencesModal';
 import ZoomUpdateModal from './ZoomUpdateModal';
 
+const ALUMNI = "ALUMNI"
+
 export const timeToSlot = {
     0: '(12am - 1am)',
     100: '(1am - 2am)',
@@ -45,6 +47,7 @@ props:
     - email: string
     - availabilities
 - isViewOnly: bool
+- refreshProfile: (ROLE, id)
 */
 export default class AlumniProfile extends Component {
     constructor(props) {
@@ -64,6 +67,8 @@ export default class AlumniProfile extends Component {
     closeTimePreferencesModal() {
         this.setState({
             timePreferencesModalOpen: false
+        }, () => {
+            this.props.refreshProfile(ALUMNI, this.props.details._id)
         })
     }
     openTimePreferencesModal() {
@@ -74,6 +79,8 @@ export default class AlumniProfile extends Component {
     closeTopicPreferencesModal() {
         this.setState({
             topicPreferencesModalOpen: false
+        }, () => {
+            this.props.refreshProfile(ALUMNI, this.props.details._id)
         })
     }
     openTopicPreferencesModal() {
@@ -84,6 +91,8 @@ export default class AlumniProfile extends Component {
     closeZoomUpdateModal() {
         this.setState({
             zoomUpdateOpen: false
+        }, () => {
+            this.props.refreshProfile(ALUMNI, this.props.details._id)
         })
     }
     openZoomUpdateModal() {

--- a/client/src/components/AlumniProfile.js
+++ b/client/src/components/AlumniProfile.js
@@ -3,6 +3,7 @@ import { Button, Card, Image } from 'semantic-ui-react';
 import LinkedInUpdate from "./LinkedInUpdate";
 import TimePreferencesModal from './TimePreferencesModal';
 import TopicPreferencesModal from './TopicPreferencesModal';
+import ZoomUpdateModal from './ZoomUpdateModal';
 
 export const timeToSlot = {
     0: '(12am - 1am)',
@@ -50,12 +51,15 @@ export default class AlumniProfile extends Component {
         super(props)
         this.state = {
             timePreferencesModalOpen: false,
-            topicPreferencesModalOpen: false
+            topicPreferencesModalOpen: false,
+            zoomUpdateOpen: false
         }
         this.openTimePreferencesModal = this.openTimePreferencesModal.bind(this)
         this.closeTimePreferencesModal = this.closeTimePreferencesModal.bind(this)
         this.openTopicPreferencesModal = this.openTopicPreferencesModal.bind(this)
         this.closeTopicPreferencesModal = this.closeTopicPreferencesModal.bind(this)
+        this.openZoomUpdateModal = this.openZoomUpdateModal.bind(this)
+        this.closeZoomUpdateModal = this.closeZoomUpdateModal.bind(this)
     }
     closeTimePreferencesModal() {
         this.setState({
@@ -77,11 +81,22 @@ export default class AlumniProfile extends Component {
             topicPreferencesModalOpen: true
         })
     }
+    closeZoomUpdateModal() {
+        this.setState({
+            zoomUpdateOpen: false
+        })
+    }
+    openZoomUpdateModal() {
+        this.setState({
+            zoomUpdateOpen: true
+        })
+    }
     render(){
         const details = this.props.details;
         const isViewOnly = this.props.isViewOnly;
         let availabilities = details.availabilities;
         let topics = details.topics;
+        let zoomLink = details.zoomLink;
         availabilities = availabilities.map(timeSlot => {
                 timeSlot.text = `${timeSlot.day} ${timeToSlot[timeSlot.time]}`
                 return timeSlot
@@ -132,12 +147,31 @@ export default class AlumniProfile extends Component {
             />
             </>
         )
+        const zoomLinkUpdate = (
+            <>
+             <Button
+                floated='right'
+                basic
+                color="blue"
+                onClick={this.openZoomUpdateModal}
+            >
+                Update Zoom Meeting ID
+            </Button>
+            <ZoomUpdateModal
+                modalOpen={this.state.zoomUpdateOpen}
+                zoomLink={zoomLink || ''}
+                closeModal={this.closeZoomUpdateModal}
+                id={details._id}
+            />
+            </>
+        )
         var canUpdate;
 
         if (!isViewOnly) {
             canUpdate = (
                 <Card.Content extra>
                     {linkedInUpdate}
+                    {zoomLinkUpdate}
                     {timeAvailabilitiesUpdate}
                     {topicAvailabilitiesUpdate}
                     {imageUpdate}

--- a/client/src/components/AlumniProfile.js
+++ b/client/src/components/AlumniProfile.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { Button, Card, Image } from 'semantic-ui-react';
 import LinkedInUpdate from "./LinkedInUpdate";
 import TimePreferencesModal from './TimePreferencesModal';
+import TopicPreferencesModal from './TopicPreferencesModal';
 
 export const timeToSlot = {
     0: '(12am - 1am)',
@@ -48,25 +49,39 @@ export default class AlumniProfile extends Component {
     constructor(props) {
         super(props)
         this.state = {
-            preferencesModalOpen: false
+            timePreferencesModalOpen: false,
+            topicPreferencesModalOpen: false
         }
-        this.openPreferencesModal = this.openPreferencesModal.bind(this)
-        this.closePreferencesModal = this.closePreferencesModal.bind(this)
+        this.openTimePreferencesModal = this.openTimePreferencesModal.bind(this)
+        this.closeTimePreferencesModal = this.closeTimePreferencesModal.bind(this)
+        this.openTopicPreferencesModal = this.openTopicPreferencesModal.bind(this)
+        this.closeTopicPreferencesModal = this.closeTopicPreferencesModal.bind(this)
     }
-    closePreferencesModal() {
+    closeTimePreferencesModal() {
         this.setState({
-            preferencesModalOpen: false
+            timePreferencesModalOpen: false
         })
     }
-    openPreferencesModal() {
+    openTimePreferencesModal() {
         this.setState({
-            preferencesModalOpen: true
+            timePreferencesModalOpen: true
+        })
+    }
+    closeTopicPreferencesModal() {
+        this.setState({
+            topicPreferencesModalOpen: false
+        })
+    }
+    openTopicPreferencesModal() {
+        this.setState({
+            topicPreferencesModalOpen: true
         })
     }
     render(){
         const details = this.props.details;
         const isViewOnly = this.props.isViewOnly;
-        let availabilities = details.availabilities
+        let availabilities = details.availabilities;
+        let topics = details.topics;
         availabilities = availabilities.map(timeSlot => {
                 timeSlot.text = `${timeSlot.day} ${timeToSlot[timeSlot.time]}`
                 return timeSlot
@@ -87,14 +102,32 @@ export default class AlumniProfile extends Component {
                 floated='right'
                 basic
                 color="blue"
-                onClick={this.openPreferencesModal}
+                onClick={this.openTimePreferencesModal}
             >
                 Update Time Availabilities
             </Button>
             <TimePreferencesModal
-                modalOpen={this.state.preferencesModalOpen}
+                modalOpen={this.state.timePreferencesModalOpen}
                 timePreferences={availabilities || []}
-                closeModal={this.closePreferencesModal}
+                closeModal={this.closeTimePreferencesModal}
+                id={details._id}
+            />
+            </>
+        )
+        const topicAvailabilitiesUpdate = (
+            <>
+            <Button
+                floated='right'
+                basic
+                color="blue"
+                onClick={this.openTopicPreferencesModal}
+            >
+                Update Topic Preferences
+            </Button>
+            <TopicPreferencesModal
+                modalOpen={this.state.topicPreferencesModalOpen}
+                topicPreferences={topics || []}
+                closeModal={this.closeTopicPreferencesModal}
                 id={details._id}
             />
             </>
@@ -106,6 +139,7 @@ export default class AlumniProfile extends Component {
                 <Card.Content extra>
                     {linkedInUpdate}
                     {timeAvailabilitiesUpdate}
+                    {topicAvailabilitiesUpdate}
                     {imageUpdate}
                 </Card.Content>
             )

--- a/client/src/components/TimePreferencesModal.js
+++ b/client/src/components/TimePreferencesModal.js
@@ -182,8 +182,7 @@ export default class TimePreferencesModal extends Component {
             submitting: true
         }, async () => {
             let payload = {
-                timePreferences: this.state.selectedTimes,
-                email: this.props.email
+                timePreferences: this.state.selectedTimes
             }
             try {
                 // TODO: Need to add end-point
@@ -208,6 +207,7 @@ export default class TimePreferencesModal extends Component {
                             icon: "success",
                         }).then(() => {
                             this.props.closeModal();
+                            window.location.reload();
                         })
                     })
                     

--- a/client/src/components/TimePreferencesModal.js
+++ b/client/src/components/TimePreferencesModal.js
@@ -185,7 +185,6 @@ export default class TimePreferencesModal extends Component {
                 timePreferences: this.state.selectedTimes
             }
             try {
-                // TODO: Need to add end-point
                 const result = await makeCall(payload, `/alumni/timePreferences/${this.props.id}`, 'patch')
                 if (!result || result.error) {
                     this.setState({

--- a/client/src/components/TimePreferencesModal.js
+++ b/client/src/components/TimePreferencesModal.js
@@ -206,7 +206,6 @@ export default class TimePreferencesModal extends Component {
                             icon: "success",
                         }).then(() => {
                             this.props.closeModal();
-                            window.location.reload();
                         })
                     })
                     

--- a/client/src/components/TopicPreferencesModal.js
+++ b/client/src/components/TopicPreferencesModal.js
@@ -82,7 +82,6 @@ export default class TopicPreferencesModal extends Component {
                             icon: "success",
                         }).then(() => {
                             this.props.closeModal();
-                            window.location.reload();
                         })
                     })
                     

--- a/client/src/components/TopicPreferencesModal.js
+++ b/client/src/components/TopicPreferencesModal.js
@@ -1,0 +1,135 @@
+import React, { Component } from 'react';
+import {Button, Modal, Segment, Header, Dropdown } from 'semantic-ui-react';
+import swal from "sweetalert";
+import { makeCall } from "../apis";
+
+/*
+props:
+    - modalOpen: boolean
+    - closeModal: ()
+    - topicPreferences: [
+        "College Shortlisting"
+    ]
+    - id
+*/
+export default class TopicPreferencesModal extends Component {
+    constructor(props){
+        super(props)
+        this.state = {
+            topics: this.props.topicPreferences,
+            topicOptions: [],
+            submitting: false
+        }
+        this.hasNewPreferences = this.hasNewPreferences.bind(this)
+        this.handleTopicSelection = this.handleTopicSelection.bind(this)
+        this.submitPreferences = this.submitPreferences.bind(this)
+    }
+
+    async componentWillMount() {
+        let topicOptions = await makeCall(null, `/alumni/topicOptions`, 'get')
+        this.setState({
+            topicOptions: topicOptions.topics.map(option => {
+                return {
+                    key: option,
+                    value: option,
+                    text: option
+                }
+            })
+        })
+    }
+
+    hasNewPreferences() {
+        if (this.state.topics.length !== this.props.topicPreferences.length) {
+            return true
+        }
+        return !this.state.topics.every(newTopic => this.props.topicPreferences.includes(newTopic))
+    }
+
+    handleTopicSelection(e, {value}) {
+        e.preventDefault()
+        this.setState({
+            topics: value
+        })
+    }
+
+    submitPreferences(e) {
+        e.preventDefault()
+        this.setState({
+            submitting: true
+        }, async () => {
+            let payload = {
+                topicPreferences: this.state.topics
+            }
+            try {
+                // TODO: Need to add end-point
+                const result = await makeCall(payload, `/alumni/topicPreferences/${this.props.id}`, 'patch')
+                if (!result || result.error) {
+                    this.setState({
+                        submitting: false
+                    }, () => {
+                        swal({
+                            title: "Error!",
+                            text: "There was an error updating your topic preferences, please try again.",
+                            icon: "error",
+                        });
+                    })
+                } else {
+                    this.setState({
+                        submitting: false
+                    }, () => {
+                        swal({
+                            title: "Done!",
+                            text: "Your topic preferences were successfully updated!",
+                            icon: "success",
+                        }).then(() => {
+                            this.props.closeModal();
+                            window.location.reload();
+                        })
+                    })
+                    
+                }
+            } catch (e) {
+                this.setState({
+                    submitting: false
+                }, () => {
+                    console.log("Error: TopicPreferencesModal#submitPreferences", e);
+                })
+            }
+        })
+    }
+
+    render() {
+        return (
+            <Modal
+                open={this.props.modalOpen}
+            >
+                <Modal.Header>Select your topic availabilities!</Modal.Header>
+                <Modal.Content>
+                    <Dropdown
+                        style={{ 'margin': '5px'}}
+                        placeholder='Select topics you would like to consult on.'
+                        fluid
+                        multiple
+                        selection
+                        options={this.state.topicOptions}
+                        value={this.state.topics}
+                        onChange={this.handleTopicSelection}
+                        name='topics'
+                    />
+                </Modal.Content>
+                <Modal.Actions>
+                    <Button
+                        primary
+                        disabled={!this.hasNewPreferences()}
+                        onClick={this.submitPreferences}
+                    >
+                        Submit New Preferences
+                    </Button>
+                    <Button onClick={this.props.closeModal}>
+                        Close
+                    </Button>
+                </Modal.Actions>
+            </Modal>
+        )
+    }
+}

--- a/client/src/components/TopicPreferencesModal.js
+++ b/client/src/components/TopicPreferencesModal.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import {Button, Modal, Segment, Header, Dropdown } from 'semantic-ui-react';
+import {Button, Modal, Dropdown } from 'semantic-ui-react';
 import swal from "sweetalert";
 import { makeCall } from "../apis";
 
@@ -61,7 +61,6 @@ export default class TopicPreferencesModal extends Component {
                 topicPreferences: this.state.topics
             }
             try {
-                // TODO: Need to add end-point
                 const result = await makeCall(payload, `/alumni/topicPreferences/${this.props.id}`, 'patch')
                 if (!result || result.error) {
                     this.setState({

--- a/client/src/components/ZoomUpdateModal.js
+++ b/client/src/components/ZoomUpdateModal.js
@@ -1,0 +1,106 @@
+import React, { Component } from 'react';
+import {Button, Modal, Input } from 'semantic-ui-react';
+import swal from "sweetalert";
+import { makeCall } from "../apis";
+
+/*
+props:
+    - modalOpen: boolean
+    - closeModal: ()
+    - zoomLink: "https://zoom.us/j/5551112222"
+    - id
+*/
+export default class ZoomUpdateModal extends Component {
+    constructor(props){
+        super(props)
+        this.state = {
+            zoomLink: this.props.zoomLink,
+            submitting: false
+        }
+        this.handleChange = this.handleChange.bind(this)
+        this.submit = this.submit.bind(this)
+    }
+
+    handleChange(e) {
+        e.preventDefault();
+        let change = {}
+        change[e.target.name] = e.target.value
+        this.setState(change)
+    }
+
+    submit(e) {
+        e.preventDefault()
+        this.setState({
+            submitting: true
+        }, async () => {
+            let payload = {
+                zoomLink: this.state.zoomLink
+            }
+            try {
+                const result = await makeCall(payload, `/alumni/zoomLink/${this.props.id}`, 'patch')
+                if (!result || result.error) {
+                    this.setState({
+                        submitting: false
+                    }, () => {
+                        swal({
+                            title: "Error!",
+                            text: "There was an error updating your zoom link, please try again.",
+                            icon: "error",
+                        });
+                    })
+                } else {
+                    this.setState({
+                        submitting: false
+                    }, () => {
+                        swal({
+                            title: "Done!",
+                            text: "Your zoom link was successfully updated!",
+                            icon: "success",
+                        }).then(() => {
+                            this.props.closeModal();
+                        })
+                    })
+                    
+                }
+            } catch (e) {
+                this.setState({
+                    submitting: false
+                }, () => {
+                    console.log("Error: ZoomUpdateModal#submit", e);
+                })
+            }
+        })
+    }
+
+    render() {
+        return (
+            <Modal
+                open={this.props.modalOpen}
+            >
+                <Modal.Header>Enter your zoom meeting link</Modal.Header>
+                <Modal.Content>
+                    <Input
+                        style={{width: '80%'}}
+                        label='Zoom Meeting Link'
+                        placeholder='https://zoom.us/j/1234567890'
+                        value={this.state.zoomLink}
+                        name='zoomLink'
+                        onChange={this.handleChange}
+                    />
+                </Modal.Content>
+                <Modal.Actions>
+                    <Button
+                        primary
+                        disabled={this.props.zoomLink === this.state.zoomLink}
+                        onClick={this.submit}
+                    >
+                        Submit
+                    </Button>
+                    <Button onClick={this.props.closeModal}>
+                        Close
+                    </Button>
+                </Modal.Actions>
+            </Modal>
+        )
+    }
+}

--- a/server/models/alumniSchema.js
+++ b/server/models/alumniSchema.js
@@ -30,6 +30,7 @@ const alumniSchema = new Schema(
     //requests: [{type: Schema.Types.ObjectId, ref: 'requestSchema'}]
     //posts: [{type: Schema.Types.ObjectId, ref: 'postSchema'}]
     availabilities: [timeAvailabilitySchema],
+    topics: {type: Array, required: false},
     timeZone: {type: Number, required: false}, // value for Date.getTimezoneOffset (Daylight Savings prevents this from being constant)
     zoomLink: {type: String, required: false}
   }

--- a/server/routes/alumni.js
+++ b/server/routes/alumni.js
@@ -79,21 +79,26 @@ router.get('/all/:timezone', async (req, res, next) => {
         })
         res.json({'alumni' : alumni});
     } catch (e) {
-        console.log("Error: util#allAlumni", e);
+        console.log("Error: alumni#allAlumni", e);
         res.status(500).send({'error' : e});
     }
 });
 
-router.get('/:id', async (req, res, next) => {
+router.get('/one/:id', async (req, res, next) => {
     try {
         let alumnus = await alumniSchema.findOne({_id: req.params.id})
         alumnus.availabilities = timezoneHelpers.applyTimezone(alumnus.availabilities, alumnus.timeZone)
         res.json({'result' : alumnus});
     } catch (e) {
-        console.log("Error: util#oneAlumni", e);
+        console.log("Error: alumni#oneAlumni", e);
         res.status(500).send({'error' : e});
     }
 });
+
+router.get('/topicOptions', async (req, res, next) => {
+    const preloadedTopics = ['College Shortlisting', 'Career Counseling', 'Essay/Personal Statement Brainstorming', 'Motivation/Performance Coaching', 'Extra-curricular Activity Strategy', 'General Counsultation']
+    res.status(200).send({topics: preloadedTopics})
+})
 
 router.patch('/timePreferences/:id', async (req, res, next) => {
     try {
@@ -103,9 +108,21 @@ router.patch('/timePreferences/:id', async (req, res, next) => {
         await alumni.save()
         res.status(200).send({message: "Successfully updated alumni's time preferences"})
     } catch (e) {
-        console.log("Error: util#timePreferences", e);
+        console.log("Error: alumni#timePreferences", e);
         res.status(500).send({'error' : e});
     }
 });
+
+router.patch('/topicPreferences/:id', async (req, res, next) => {
+    try {
+        const alumni = await alumniSchema.findOne({_id: req.params.id})
+        alumni.topics = req.body.topicPreferences
+        await alumni.save()
+        res.status(200).send({message: "Successfully updated alumni's topic preferences"})
+    } catch (e) {
+        console.log("Error: alumni#topicPreferences", e);
+        res.status(500).send({'error' : e});
+    }
+})
 
 module.exports = router;

--- a/server/routes/alumni.js
+++ b/server/routes/alumni.js
@@ -125,4 +125,16 @@ router.patch('/topicPreferences/:id', async (req, res, next) => {
     }
 })
 
+router.patch('/zoomLink/:id', async (req, res, next) => {
+    try {
+        const alumni = await alumniSchema.findOne({_id: req.params.id})
+        alumni.zoomLink = req.body.zoomLink
+        await alumni.save()
+        res.status(200).send({message: "Successfully updated alumni's zoom link"})
+    } catch (e) {
+        console.log("Error: alumni#zoomLink", e);
+        res.status(500).send({'error' : e});
+    }
+})
+
 module.exports = router;

--- a/server/routes/students.js
+++ b/server/routes/students.js
@@ -55,7 +55,7 @@ router.post('/', async (req, res, next) => {
     }
 });
 
-router.get('/:id', async (req, res, next) => {
+router.get('/one/:id', async (req, res, next) => {
     try {
         const dbData = await studentSchema.findOne({_id: req.params.id})
         res.json({'result' : dbData});


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31665569/83092497-71d5c000-a06b-11ea-9f0c-ac555e29d21f.png)
![image](https://user-images.githubusercontent.com/31665569/83095068-98e2c080-a070-11ea-8bba-1e480aa4aade.png)

* Added `topics` on alumniSchema that stores a list of topics alumni can choose to consult
* Added a separate modal that allows alumni to pick topics they want to consult
* On successful addition of new topics and new time preferences, refresh the page since a refetch is required to show updated times and topics
* Added button to allow alumni to update ZoomLink (I did not tag on a refresh on updating Zoom, since this it's unlikely that the user won't refresh before they need to update the zoom link again, let me know what you think)