### PR TITLE
Frontend/request modal

### DIFF
--- a/client/src/components/AlumniDirectory.js
+++ b/client/src/components/AlumniDirectory.js
@@ -178,7 +178,7 @@ export default class AlumniDirectory extends Component {
     }
 
     getEntries() {
-        return makeCall(null, `/alumni/all/${this.props.timezone}`, 'get').catch(e => console.log(e))
+        return makeCall(null, `/alumni/all/`, 'get').catch(e => console.log(e))
     }
 
     search(value) {

--- a/client/src/components/AlumniDirectory.js
+++ b/client/src/components/AlumniDirectory.js
@@ -197,7 +197,7 @@ export default class AlumniDirectory extends Component {
             } else {
                 if (this.state.allText[i].match(searchPattern) !== null) {
                     numResults += 1
-                    display.push(this.constructProfile(this.state.entries[i]), i)
+                    display.push(this.constructProfile(this.state.entries[i], i))
                 }
             }
             i++;

--- a/client/src/components/AlumniDirectory.js
+++ b/client/src/components/AlumniDirectory.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { Card, Image, Search, Pagination, Grid, Segment, Button, Dropdown } from 'semantic-ui-react'
 import { makeCall } from '../apis';
+import RequestModal from './RequestModal'
 
 // Filter dropdown options
 const searchOptions = [
@@ -49,18 +50,36 @@ props:
 - timezone: Number
 */
 export default class AlumniDirectory extends Component {
-    state = {
-        activePage: 1,
-        numEntries: 0,
-        isLoading: false,
-        value: '',
-        totalPages: 0,
-        entries:[],
-        gradYears: [],
-        allText: [],
-        display: [],
-        numResults: 0,
-        filter: 'all'
+    constructor(props) {
+        super(props)
+        this.state = {
+            activePage: 1,
+            numEntries: 0,
+            isLoading: false,
+            value: '',
+            totalPages: 0,
+            entries:[],
+            gradYears: [],
+            allText: [],
+            display: [],
+            numResults: 0,
+            filter: 'all',
+            requestModalOpen: false,
+            alumniDetails: null,
+        }
+        this.openRequestModal = this.openRequestModal.bind(this)
+        this.closeRequestModal = this.closeRequestModal.bind(this)
+    }
+
+    closeRequestModal() {
+        this.setState({
+            requestModalOpen: false
+        })
+    }
+    openRequestModal() {
+        this.setState({
+            requestModalOpen: true
+        })
     }
 
     async componentWillMount() {
@@ -77,6 +96,7 @@ export default class AlumniDirectory extends Component {
         let gradYears = [];
         let allText = [];
         let display = [];
+        let i = 0;
         for (let post of entries) {
             if(!gradYears.find(year => year['value'] === post.gradYear)) {
                 gradYears.push({
@@ -91,7 +111,8 @@ export default class AlumniDirectory extends Component {
                          + post.company + ' '
                          + post.name + ' '
                          + post.gradYear);
-            display.push(this.constructProfile(post));
+            display.push(this.constructProfile(post, i));
+            i++;
         }
         gradYears.sort(function(a,b){return a.value-b.value})
         this.setState({
@@ -101,7 +122,7 @@ export default class AlumniDirectory extends Component {
                      })
     }
 
-    constructProfile(post) {
+    constructProfile(post, i) {
         return (
             <Grid.Row columns={2}>
                 <Grid.Column width={4}>
@@ -132,11 +153,28 @@ export default class AlumniDirectory extends Component {
                             <Card.Description>Company: {post.company}</Card.Description>
                             <br />
                         </Card.Content>
-                        {requestVisible(this.props.isAlumniView, post)}
+                        {this.requestVisible(this.props.isAlumniView, post, i)}
                     </Card>
                 </Grid.Column>
             </Grid.Row>
         )
+    }
+
+    requestVisible(isAlumniView, post, i) {
+        var requestButton;
+                if (('zoomLink' in post) && !isAlumniView) {
+                    requestButton = <Button 
+                                    primary 
+                                    data-id={i}
+                                    onClick={this.handleRequestButton.bind(this)}>
+                                        Make Request
+                                    </Button>
+                } else if (!isAlumniView){
+                    requestButton = <Button disabled>Make Request</Button>
+                } else {
+                    requestButton = null;
+                }
+        return requestButton
     }
 
     getEntries() {
@@ -159,7 +197,7 @@ export default class AlumniDirectory extends Component {
             } else {
                 if (this.state.allText[i].match(searchPattern) !== null) {
                     numResults += 1
-                    display.push(this.constructProfile(this.state.entries[i]))
+                    display.push(this.constructProfile(this.state.entries[i]), i)
                 }
             }
             i++;
@@ -182,6 +220,11 @@ export default class AlumniDirectory extends Component {
             this.search(value)
         }
         this.setState({ [name]: value })
+    }
+    handleRequestButton(e) {
+        this.setState({alumniDetails: this.state.entries[e.currentTarget.dataset.id]})
+        console.log(this.state.alumniDetails)
+        this.openRequestModal()
     }
 
     render(){
@@ -267,6 +310,14 @@ export default class AlumniDirectory extends Component {
                 
                 {searchRow}
                 {resultsRow}
+                {this.state.requestModalOpen && 
+                    <RequestModal
+                    modalOpen={this.state.requestModalOpen}
+                    closeModal={this.closeRequestModal}
+                    alumni={this.state.alumniDetails}
+                    />
+                }
+                
                 {pageGenerator(display, pageSize, activePage)}
 
                 <Grid.Row stretched>
@@ -296,18 +347,4 @@ function pageGenerator(profiles, pageSize, activePage) {
         display.push(profiles[(activePage - 1) * pageSize + i])
     }
     return display
-}
-
-// Args: isAlumniView (bool), alumni (object)
-// Returns: jsx for the request button (either active, disabled, hidden)
-function requestVisible(isAlumniView, post) {
-    var requestButton;
-            if (('zoomLink' in post) && !isAlumniView) {
-                requestButton = <Button primary>Make Request</Button>
-            } else if (!isAlumniView){
-                requestButton = <Button disabled>Make Request</Button>
-            } else {
-                requestButton = null;
-            }
-    return requestButton
 }

--- a/client/src/components/AlumniDirectory.js
+++ b/client/src/components/AlumniDirectory.js
@@ -67,18 +67,12 @@ export default class AlumniDirectory extends Component {
             requestModalOpen: false,
             alumniDetails: null,
         }
-        this.openRequestModal = this.openRequestModal.bind(this)
-        this.closeRequestModal = this.closeRequestModal.bind(this)
+        this.toggleRequestModal = this.toggleRequestModal.bind(this)
     }
 
-    closeRequestModal() {
+    toggleRequestModal() {
         this.setState({
-            requestModalOpen: false
-        })
-    }
-    openRequestModal() {
-        this.setState({
-            requestModalOpen: true
+            requestModalOpen: !this.state.requestModalOpen
         })
     }
 
@@ -223,8 +217,7 @@ export default class AlumniDirectory extends Component {
     }
     handleRequestButton(e) {
         this.setState({alumniDetails: this.state.entries[e.currentTarget.dataset.id]})
-        console.log(this.state.alumniDetails)
-        this.openRequestModal()
+        this.toggleRequestModal()
     }
 
     render(){
@@ -313,7 +306,7 @@ export default class AlumniDirectory extends Component {
                 {this.state.requestModalOpen && 
                     <RequestModal
                     modalOpen={this.state.requestModalOpen}
-                    closeModal={this.closeRequestModal}
+                    closeModal={this.toggleRequestModal}
                     alumni={this.state.alumniDetails}
                     />
                 }

--- a/client/src/components/RequestModal.js
+++ b/client/src/components/RequestModal.js
@@ -63,17 +63,14 @@ export default class RequestModal extends Component {
     }
 
     async createAvailabilityOptions(availabilities) {
-        console.log(availabilities)
         /* 
-         * Offset is in minutes, annoyingly, and in the opposite direction 
-         * that you'd expect. This means that if you are in UTC -4 (EST), 
-         * it returns 240 (not -240 to reflect being 4 hours behind)
+         * Offset is in minutes and in the opposite direction 
+         * that you'd expect. For UTC -4 (EST), it returns 240 
+         * (not -240 to reflect being 4 hours behind)
          * That's why there's a tiny bit of math in the payload, to conform
-         * with our date model (which makes more sense)
+         * with our date model
          */
-        let timeOffset = await new Date().getTimezoneOffset()
-        console.log(timeOffset)
-        console.log(this.props.alumni.timeZone)
+        let timeOffset = new Date().getTimezoneOffset()
         let adjustedAvailabilities = await makeCall({availabilities: availabilities,
                                                     offset: (-(timeOffset/60)*100)}, 
                                                     '/request/applyRequesterTimezone', 
@@ -87,7 +84,6 @@ export default class RequestModal extends Component {
                 value: option.id,
             })
         }
-        console.log(availabilityOptions)
         this.setState({availabilityOptions: availabilityOptions})
     }
 
@@ -195,7 +191,6 @@ export default class RequestModal extends Component {
                                     <Form.TextArea 
                                         label={'Leave a note for ' + this.state.alumni.name + ':'}
                                         placeholder='Provide extra information here'
-                                        fluid
                                         onChange={this.handleValueChange}
                                         value={this.state.note}
                                         name='note'

--- a/client/src/components/RequestModal.js
+++ b/client/src/components/RequestModal.js
@@ -1,138 +1,36 @@
 import React, { Component } from 'react';
-import {Button, Modal, Segment, Header, Dropdown, Image, Grid} from 'semantic-ui-react';
+import {Button, Modal, Image, Grid, Form} from 'semantic-ui-react';
 import swal from "sweetalert";
 import { makeCall } from "../apis";
 
-const dayOptions = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
-    .map(day => {
-        return {
-            key: day.toLowerCase(),
-            text: day,
-            value: day
-        }
-    })
+
 export const timeSlotOptions = [
-    {
-        key: 'slot1',
-        value: 0,
-        text: '12am - 1am'
-    },
-    {
-        key: 'slot2',
-        value: 100,
-        text: '1am - 2am'
-    },
-    {
-        key: 'slot3',
-        value: 200,
-        text: '2am - 3am'
-    },
-    {
-        key: 'slot4',
-        value: 300,
-        text: '3am - 4am'
-    },
-    {
-        key: 'slot5',
-        value: 400,
-        text: '4am - 5am'
-    },
-    {
-        key: 'slot6',
-        value: 500,
-        text: '5am - 6am'
-    },
-    {
-        key: 'slot7',
-        value: 600,
-        text: '6am - 7am'
-    },
-    {
-        key: 'slot8',
-        value: 700,
-        text: '7am - 8am'
-    },
-    {
-        key: 'slot9',
-        value: 800,
-        text: '8am - 9am'
-    },
-    {
-        key: 'slot10',
-        value: 900,
-        text: '9am - 10am'
-    },
-    {
-        key: 'slot11',
-        value: 1000,
-        text: '10am - 11am'
-    },
-    {
-        key: 'slot12',
-        value: 1100,
-        text: '11am - 12pm'
-    },
-    {
-        key: 'slot13',
-        value: 1200,
-        text: '12p - 1pm'
-    },
-    {
-        key: 'slot14',
-        value: 1300,
-        text: '1pm - 2pm'
-    },
-    {
-        key: 'slot15',
-        value: 1400,
-        text: '2pm - 3pm'
-    },
-    {
-        key: 'slot16',
-        value: 1500,
-        text: '3pm - 4pm'
-    },
-    {
-        key: 'slot17',
-        value: 1600,
-        text: '4pm - 5pm'
-    },
-    {
-        key: 'slot18',
-        value: 1700,
-        text: '5pm - 6pm'
-    },
-    {
-        key: 'slot19',
-        value: 1800,
-        text: '6pm - 7pm'
-    },
-    {
-        key: 'slot20',
-        value: 1900,
-        text: '7pm - 8pm'
-    },
-    {
-        key: 'slot21',
-        value: 2000,
-        text: '8pm - 9pm'
-    },
-    {
-        key: 'slot22',
-        value: 2100,
-        text: '9pm - 10pm'
-    },
-    {
-        key: 'slot23',
-        value: 2200,
-        text: '10pm - 11pm'
-    },
-    {
-        key: 'slot24',
-        value: 2300,
-        text: '11pm - 12am'
-    },
+    '12am - 1am',
+    '1am - 2am',
+    '2am - 3am',
+    '3am - 4am',
+    '4am - 5am',
+    '5am - 6am',
+    '6am - 7am',
+    '7am - 8am',
+    '8am - 9am',
+    '9am - 10am',
+    '10am - 11am',
+    '11am - 12pm',
+    '12p - 1pm',
+    '1pm - 2pm',
+    '2pm - 3pm',
+    '3pm - 4pm',
+    '4pm - 5pm',
+    '5pm - 6pm',
+    '6pm - 7pm',
+    '7pm - 8pm',
+    '8pm - 9pm',
+    '9pm - 10pm',
+    '10pm - 11pm',
+    '11pm - 12am'
 ]
+
 
 /*
 props:
@@ -147,10 +45,11 @@ export default class RequestModal extends Component {
         this.state = {
             alumni: null,
             studentId: '',
-            options: [],
-            value: '',
-            topic: '',
-            notes: '',
+            availabilityOptions: [],
+            availabilityValue: '',
+            topicOptions: [],
+            topicValue: '',
+            note: '',
             submitting: false
         }
         this.handleValueChange = this.handleValueChange.bind(this)
@@ -159,10 +58,11 @@ export default class RequestModal extends Component {
 
     async componentWillMount() {
         await this.setState({alumni: this.props.alumni})
-        this.createOptions(this.state.alumni.availabilities)
+        this.createAvailabilityOptions(this.state.alumni.availabilities)
+        this.createTopicOptions(this.state.alumni.topics)
     }
 
-    async createOptions(availabilities) {
+    async createAvailabilityOptions(availabilities) {
         console.log(availabilities)
         /* 
          * Offset is in minutes, annoyingly, and in the opposite direction 
@@ -178,8 +78,29 @@ export default class RequestModal extends Component {
                                                     offset: (-(timeOffset/60)*100)}, 
                                                     '/request/applyRequesterTimezone', 
                                                     'patch')
-        console.log(adjustedAvailabilities)
-        this.setState({options: adjustedAvailabilities})
+        let availabilityOptions = []
+        for (let option of adjustedAvailabilities.availabilities) {
+            let readableOption = option.day + ', ' + timeSlotOptions[(option.time/100)]
+            availabilityOptions.push({
+                key: option.id,
+                text: readableOption,
+                value: option.id,
+            })
+        }
+        console.log(availabilityOptions)
+        this.setState({availabilityOptions: availabilityOptions})
+    }
+
+    createTopicOptions(topics) {
+        let topicOptions = []
+        for (let topic of topics) {
+            topicOptions.push({
+                key: topic,
+                text: topic,
+                value: topic  
+            })
+        }
+        this.setState({topicOptions: topicOptions})
     }
 
     submitRequest(e) {
@@ -223,10 +144,10 @@ export default class RequestModal extends Component {
         })
     }
 
-    handleValueChange(e, {value}) {
+    handleValueChange(e, {name, value}) {
         e.preventDefault();
         this.setState({
-            value: value
+            [name]: value
         })
     }
 
@@ -239,38 +160,59 @@ export default class RequestModal extends Component {
                 <Modal.Header>Schedule a meeting with {this.state.alumni.name}!</Modal.Header>
                 <Modal.Content>
                     <Grid>
-                    <Grid.Row columns={"equal"}>
-                    <Grid.Column width={3}>
-                    <Image
-                        floated='left'
-                        size='small'
-                        src={this.state.alumni.imageURL}
-                        rounded
-                    />
-                    </Grid.Column>
-                    <Grid.Column>
-                    <Segment fluid>
-                        <Header>Choose a day:</Header>
-                        
-                        <Dropdown
-                            style={{ 'margin': '5px'}}
-                            placeholder='Day'
-                            fluid
-                            selection
-                            options={this.state.dayOptions} 
-                            onChange={this.handleValueChange}
-                            value={this.state.day}
-                            name='day'
-                        />
-                    </Segment>
-                    </Grid.Column>
-                    </Grid.Row>
+                        <Grid.Row columns={"equal"}>
+                            <Grid.Column width={3}>
+                                <Image
+                                    floated='left'
+                                    size='small'
+                                    src={this.state.alumni.imageURL}
+                                    rounded
+                                />
+                            </Grid.Column>
+                            <Grid.Column>
+                                <Form>
+                                    <Form.Dropdown 
+                                        label='Choose an availability:'
+                                        placeholder='Day of the Week, Time'
+                                        fluid
+                                        selection
+                                        search
+                                        options={this.state.availabilityOptions} 
+                                        onChange={this.handleValueChange}
+                                        value={this.state.availabilityValue}
+                                        name='availabilityValue'
+                                    />
+                                    <Form.Dropdown
+                                        label={'Choose a topic offered by ' + this.state.alumni.name + ':'}
+                                        placeholder='Topic'
+                                        fluid
+                                        selection
+                                        options={this.state.topicOptions} 
+                                        onChange={this.handleValueChange}
+                                        value={this.state.topicValue}
+                                        name='topicValue'
+                                    />
+                                    <Form.TextArea 
+                                        label={'Leave a note for ' + this.state.alumni.name + ':'}
+                                        placeholder='Provide extra information here'
+                                        fluid
+                                        onChange={this.handleValueChange}
+                                        value={this.state.note}
+                                        name='note'
+                                    />
+                                </Form>
+                            </Grid.Column>
+                        </Grid.Row>
                     </Grid>
                 </Modal.Content>
                 <Modal.Actions>
                     <Button
                         primary
                         onClick={this.submitRequest}
+                        disabled={
+                                (this.state.topicValue === '') || 
+                                (this.state.availabilityValue === '')
+                            }
                     >
                         Submit Request
                     </Button>

--- a/client/src/components/RequestModal.js
+++ b/client/src/components/RequestModal.js
@@ -1,0 +1,287 @@
+import React, { Component } from 'react';
+import {Button, Modal, Segment, Header, Dropdown, Image, Grid} from 'semantic-ui-react';
+import swal from "sweetalert";
+import { makeCall } from "../apis";
+
+const dayOptions = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+    .map(day => {
+        return {
+            key: day.toLowerCase(),
+            text: day,
+            value: day
+        }
+    })
+export const timeSlotOptions = [
+    {
+        key: 'slot1',
+        value: 0,
+        text: '12am - 1am'
+    },
+    {
+        key: 'slot2',
+        value: 100,
+        text: '1am - 2am'
+    },
+    {
+        key: 'slot3',
+        value: 200,
+        text: '2am - 3am'
+    },
+    {
+        key: 'slot4',
+        value: 300,
+        text: '3am - 4am'
+    },
+    {
+        key: 'slot5',
+        value: 400,
+        text: '4am - 5am'
+    },
+    {
+        key: 'slot6',
+        value: 500,
+        text: '5am - 6am'
+    },
+    {
+        key: 'slot7',
+        value: 600,
+        text: '6am - 7am'
+    },
+    {
+        key: 'slot8',
+        value: 700,
+        text: '7am - 8am'
+    },
+    {
+        key: 'slot9',
+        value: 800,
+        text: '8am - 9am'
+    },
+    {
+        key: 'slot10',
+        value: 900,
+        text: '9am - 10am'
+    },
+    {
+        key: 'slot11',
+        value: 1000,
+        text: '10am - 11am'
+    },
+    {
+        key: 'slot12',
+        value: 1100,
+        text: '11am - 12pm'
+    },
+    {
+        key: 'slot13',
+        value: 1200,
+        text: '12p - 1pm'
+    },
+    {
+        key: 'slot14',
+        value: 1300,
+        text: '1pm - 2pm'
+    },
+    {
+        key: 'slot15',
+        value: 1400,
+        text: '2pm - 3pm'
+    },
+    {
+        key: 'slot16',
+        value: 1500,
+        text: '3pm - 4pm'
+    },
+    {
+        key: 'slot17',
+        value: 1600,
+        text: '4pm - 5pm'
+    },
+    {
+        key: 'slot18',
+        value: 1700,
+        text: '5pm - 6pm'
+    },
+    {
+        key: 'slot19',
+        value: 1800,
+        text: '6pm - 7pm'
+    },
+    {
+        key: 'slot20',
+        value: 1900,
+        text: '7pm - 8pm'
+    },
+    {
+        key: 'slot21',
+        value: 2000,
+        text: '8pm - 9pm'
+    },
+    {
+        key: 'slot22',
+        value: 2100,
+        text: '9pm - 10pm'
+    },
+    {
+        key: 'slot23',
+        value: 2200,
+        text: '10pm - 11pm'
+    },
+    {
+        key: 'slot24',
+        value: 2300,
+        text: '11pm - 12am'
+    },
+]
+
+/*
+props:
+    - modalOpen: boolean
+    - closeModal: ()
+    - alumni (contains all data from alumni schema)
+    - id
+*/
+export default class RequestModal extends Component {
+    constructor(props){
+        super(props)
+        this.state = {
+            alumni: null,
+            studentId: '',
+            dayOptions: [],
+            day: '',
+            topic: '',
+            notes: '',
+            submitting: false
+        }
+        this.handleDayChange = this.handleDayChange.bind(this)
+        this.submitRequest = this.submitRequest.bind(this)
+    }
+
+    async componentWillMount() {
+        await this.setState({alumni: this.props.alumni})
+        this.createDayOptions(this.state.alumni.availabilities)
+    }
+
+    createDayOptions(availabilities) {
+        let days = [];
+        let timeOffset = new Date().getTimezoneOffset()
+        for (let day of availabilities) {
+            let adjustedTime = day.time + timeOffset
+            console.log(adjustedTime)
+            if (adjustedTime < 0) {
+                //TODO
+            } else if (adjustedTime > 2400) {
+                //TODO
+            } else {
+                if (!days.find(d => d['value'] === day.day)) {
+                    days.push({
+                        key: day.day.toLowerCase(),
+                        text: day.day,
+                        value: day.day
+                    })
+                }
+            }
+        }
+        this.setState({dayOptions: days})
+    }
+
+    submitRequest(e) {
+        e.preventDefault()
+        this.setState({
+            submitting: true
+        }, async () => {
+            try {
+                const result = true;
+                if (!result || result.error) {
+                    this.setState({
+                        submitting: false
+                    }, () => {
+                        swal({
+                            title: "Error!",
+                            text: "There was an error updating your time preferences, please try again.",
+                            icon: "error",
+                        });
+                    })
+                } else {
+                    this.setState({
+                        submitting: false
+                    }, () => {
+                        swal({
+                            title: "Done!",
+                            text: "Your time preferences were successfully updated!",
+                            icon: "success",
+                        }).then(() => {
+                            this.props.closeModal();
+                        })
+                    })
+                    
+                }
+            } catch (e) {
+                this.setState({
+                    submitting: false
+                }, () => {
+                    console.log("Error: RequestModal#makeRequest", e);
+                })
+            }
+        })
+    }
+
+    handleDayChange(e, {value}) {
+        e.preventDefault();
+        this.setState({
+            day: value
+        })
+    }
+
+
+    render() {
+        return (
+            <Modal
+                open={this.props.modalOpen}
+            >
+                <Modal.Header>Schedule a meeting with {this.state.alumni.name}!</Modal.Header>
+                <Modal.Content>
+                    <Grid>
+                    <Grid.Row columns={"equal"}>
+                    <Grid.Column width={3}>
+                    <Image
+                        floated='left'
+                        size='small'
+                        src={this.state.alumni.imageURL}
+                        rounded
+                    />
+                    </Grid.Column>
+                    <Grid.Column>
+                    <Segment fluid>
+                        <Header>Choose a day:</Header>
+                        
+                        <Dropdown
+                            style={{ 'margin': '5px'}}
+                            placeholder='Day'
+                            fluid
+                            selection
+                            options={this.state.dayOptions} 
+                            onChange={this.handleDayChange}
+                            value={this.state.day}
+                            name='day'
+                        />
+                    </Segment>
+                    </Grid.Column>
+                    </Grid.Row>
+                    </Grid>
+                </Modal.Content>
+                <Modal.Actions>
+                    <Button
+                        primary
+                        onClick={this.submitRequest}
+                    >
+                        Submit Request
+                    </Button>
+                    <Button onClick={this.props.closeModal}>
+                        Close
+                    </Button>
+                </Modal.Actions>
+            </Modal>
+        )
+    }
+}

--- a/server/helpers/timezoneHelpers.js
+++ b/server/helpers/timezoneHelpers.js
@@ -38,7 +38,7 @@ const timezoneUtil = {
             return timeSlots
         }
         return timeSlots.map( timeSlot => {
-            let newTimeRaw = timeSlot.time + (timezone * (-1))
+            let newTimeRaw = timeSlot.time - timezone
             let newTime = (2400 + newTimeRaw) % 2400
             if (newTimeRaw < 0) {
                 // move day backward
@@ -68,7 +68,7 @@ const timezoneUtil = {
         return timeSlots.map( timeSlot => {
             // if timezone is positive, we need to add offset
             // if timezone is negative, we need to substract offset 
-            let newTimeRaw = timeSlot.time + timezone
+            let newTimeRaw = timeSlot.time + (timezone)
             let newTime = (2400 + newTimeRaw) % 2400
             if (newTimeRaw < 0) {
                 // move day backward

--- a/server/routes/alumni.js
+++ b/server/routes/alumni.js
@@ -70,14 +70,9 @@ router.post('/', async (req, res, next) => {
     }
 });
 
-router.get('/all/:timezone', async (req, res, next) => {
+router.get('/all/', async (req, res, next) => {
     try {
-        let timezone = req.params.timezone
         let alumni = await alumniSchema.find()
-        alumni = alumni.map(alumnus => {
-            alumnus.availabilities = timezoneHelpers.applyTimezone(alumnus.availabilities, timezone)
-            return alumnus
-        })
         res.json({'alumni' : alumni});
     } catch (e) {
         console.log("Error: alumni#allAlumni", e);

--- a/server/routes/alumni.js
+++ b/server/routes/alumni.js
@@ -41,7 +41,7 @@ router.post('/', async (req, res, next) => {
                 //requests: [{type: Schema.Types.ObjectId, ref: 'requestSchema'}]
                 //posts: [{type: Schema.Types.ObjectId, ref: 'postSchema'}]
                 availabilities: availabilities,
-                timeZone: timeZone,
+                timeZone: -timeZone,
                 zoomLink: zoomLink,
                 approved: approved
             }

--- a/server/routes/requests.js
+++ b/server/routes/requests.js
@@ -3,12 +3,29 @@ var router = express.Router();
 var alumniSchema = require('../models/alumniSchema');
 var studentSchema = require('../models/studentSchema');
 var requestSchema = require('../models/requestSchema');
+var timezoneHelpers = require("../helpers/timezoneHelpers")
 require('mongoose').Promise = global.Promise
 
 router.get('/', async (req, res, next) => {
     res.status(200).send({
         message: "requests page!"
     })
+})
+
+router.patch('/applyRequesterTimezone', async (req, res, next) => {
+    try {
+        const agnosticAvailabilities = req.body.availabilities;
+        const timezone = req.body.offset
+        const availabilities = await timezoneHelpers.applyTimezone(agnosticAvailabilities, timezone)
+        res.status(200).send({
+            availabilities: availabilities
+        })
+    } catch (e) {
+        console.log(e)
+        res.status(500).send({
+            message: ('failed to apply timezone. Reason: ' + e)
+        })
+    }
 })
 
 router.post('/addRequest/', async (req, res, next) => {

--- a/server/routes/requests.js
+++ b/server/routes/requests.js
@@ -23,7 +23,7 @@ router.patch('/applyRequesterTimezone', async (req, res, next) => {
     } catch (e) {
         console.log(e)
         res.status(500).send({
-            message: ('failed to apply timezone. Reason: ' + e)
+            message: ('failed to apply timezone (request/applyRequesterTimezone) Reason: ' + e)
         })
     }
 })

--- a/server/routes/students.js
+++ b/server/routes/students.js
@@ -28,7 +28,7 @@ router.post('/', async (req, res, next) => {
                 grade: grade,
                 // requests: [{type: Schema.Types.ObjectId, ref: 'requestSchema'}]
                 // issuesLiked: [{type: Schema.Types.ObjectId, ref: 'issueSchema'}]
-                timeZone: timeZone,
+                timeZone: -timeZone,
             }
         )
         const user_instance = new userSchema(


### PR DESCRIPTION
This PR is mostly frontend changes, though it contains minor tweaks to how timezones work.
Requests will require a bit of an overhaul on the backend, so this serves to get the ball rolling
Ideally the changes to requests will not take too long, and submission can be implemented.

Question: Should how do we want to handle multiple requests to the same timeslot? Do we want to give requests a 1/2 week expiry, and block others from making requests during that same time?

Modal upon clicking Request:
<img width="790" alt="Screen Shot 2020-06-03 at 10 28 12 PM" src="https://user-images.githubusercontent.com/54961598/83708528-7dd0fd00-a5ea-11ea-909c-f26937d59dbc.png">

Searchable Dropdown for availabilities:
<img width="811" alt="Screen Shot 2020-06-03 at 10 29 25 PM" src="https://user-images.githubusercontent.com/54961598/83708555-8aedec00-a5ea-11ea-9d2c-aedddb47a2d3.png">

Regular Dropdown for topics:
<img width="839" alt="Screen Shot 2020-06-03 at 10 29 34 PM" src="https://user-images.githubusercontent.com/54961598/83708599-9e00bc00-a5ea-11ea-9030-77413e4270b1.png">

Submit Request is only enabled when availability and topic are selected:
<img width="784" alt="Screen Shot 2020-06-03 at 10 29 43 PM" src="https://user-images.githubusercontent.com/54961598/83708676-d3a5a500-a5ea-11ea-8de1-3ab472259d52.png">

Text area and corresponding states in action:
<img width="1414" alt="Screen Shot 2020-06-03 at 10 30 38 PM" src="https://user-images.githubusercontent.com/54961598/83708705-e61fde80-a5ea-11ea-9f2a-9cbbddedac07.png">
