### PR TITLE
Fullstack/profile update - interests adding and removing for alumni

### DIFF
--- a/client/src/components/AlumniProfile.js
+++ b/client/src/components/AlumniProfile.js
@@ -1,10 +1,12 @@
 import React, { Component } from 'react';
-import { Button, Card, Image } from 'semantic-ui-react';
+import { Button, Card, Image, Grid, Label, Icon, Segment } from 'semantic-ui-react';
 import LinkedInUpdate from "./LinkedInUpdate";
 import TimePreferencesModal from './TimePreferencesModal';
 import TopicPreferencesModal from './TopicPreferencesModal';
 import ZoomUpdateModal from './ZoomUpdateModal';
 import ImageUpdateModal from './ImageUpdateModal';
+import InterestsUpdateModal from './InterestsUpdateModal';
+import { makeCall } from "../apis";
 
 const ALUMNI = "ALUMNI"
 
@@ -58,7 +60,8 @@ export default class AlumniProfile extends Component {
             timePreferencesModalOpen: false,
             topicPreferencesModalOpen: false,
             zoomUpdateOpen: false,
-            imageModalOpen: false
+            imageModalOpen: false,
+            removingInterest: false
         }
         this.openTimePreferencesModal = this.openTimePreferencesModal.bind(this)
         this.closeTimePreferencesModal = this.closeTimePreferencesModal.bind(this)
@@ -68,6 +71,9 @@ export default class AlumniProfile extends Component {
         this.closeZoomUpdateModal = this.closeZoomUpdateModal.bind(this)
         this.openImageModal = this.openImageModal.bind(this)
         this.closeImageModal = this.closeImageModal.bind(this)
+        this.openInterestsModal = this.openInterestsModal.bind(this)
+        this.closeInterestsModal = this.closeInterestsModal.bind(this)
+        this.getInterests = this.getInterests.bind(this)
     }
     closeTimePreferencesModal() {
         this.setState({
@@ -117,8 +123,53 @@ export default class AlumniProfile extends Component {
             this.props.refreshProfile(ALUMNI, this.props.details._id)
         })
     }
-
-    render(){
+    openInterestsModal() {
+        this.setState({
+            interestsModalOpen: true
+        })
+    }
+    closeInterestsModal() {
+        this.setState({
+            interestsModalOpen: false
+        }, () => {
+            this.props.refreshProfile(ALUMNI, this.props.details._id)
+        })
+    }
+    async removeInterest(e, interestIdToRemove) {
+        e.preventDefault()
+        this.setState({removeInterest: true},
+            async () => {
+                await makeCall({interestIdToRemove: interestIdToRemove}, `/alumni/interests/remove/${this.props.details._id}`, 'patch')
+                this.setState({
+                    removeInterest: true
+                }, () =>
+                this.props.refreshProfile(ALUMNI, this.props.details._id)
+                )
+            })
+    }
+    getInterests() {
+        return this.props.details.interests && this.props.details.interests.length && this.props.details.interests.map(interest => {
+            return (
+                <Label
+                    key={interest._id}
+                    style={{
+                        'margin': '3px'
+                    }}
+                    color='blue'
+                >
+                    {interest.name}
+                    {
+                        !this.props.isViewOnly &&
+                        <Icon
+                            onClick={(e) => this.removeInterest(e, interest._id)}
+                            name='delete'
+                        />
+                    }
+                </Label>
+            )
+        })
+    }
+    render() {
         const details = this.props.details;
         const isViewOnly = this.props.isViewOnly;
         let availabilities = details.availabilities;
@@ -135,8 +186,9 @@ export default class AlumniProfile extends Component {
         )
         const imageUpdate = (
             <>
-            <Button 
-                floated="right"
+            <Button
+                style={{'margin': '2px'}}
+                floated="left"
                 basic
                 color="blue"
                 onClick={this.openImageModal}
@@ -154,6 +206,7 @@ export default class AlumniProfile extends Component {
         const timeAvailabilitiesUpdate = (
             <>
             <Button
+                style={{'margin': '2px'}}
                 floated='right'
                 basic
                 color="blue"
@@ -172,6 +225,7 @@ export default class AlumniProfile extends Component {
         const topicAvailabilitiesUpdate = (
             <>
             <Button
+                style={{'margin': '2px'}}
                 floated='right'
                 basic
                 color="blue"
@@ -190,6 +244,7 @@ export default class AlumniProfile extends Component {
         const zoomLinkUpdate = (
             <>
              <Button
+                style={{'margin': '2px'}}
                 floated='right'
                 basic
                 color="blue"
@@ -205,17 +260,46 @@ export default class AlumniProfile extends Component {
             />
             </>
         )
+
+        const interestsUpdate = (
+            <>
+            <Button
+                style={{'margin': '2px'}}
+                floated='right'
+                basic
+                color="blue"
+                onClick={this.openInterestsModal}
+            >
+                Add Interests
+            </Button>
+            <InterestsUpdateModal
+                modalOpen={this.state.interestsModalOpen}
+                closeModal={this.closeInterestsModal}
+                id={details._id}
+            />
+            </>
+        )
         var canUpdate;
 
         if (!isViewOnly) {
             canUpdate = (
+                <>
                 <Card.Content extra>
-                    {linkedInUpdate}
-                    {zoomLinkUpdate}
-                    {timeAvailabilitiesUpdate}
-                    {topicAvailabilitiesUpdate}
-                    {imageUpdate}
+                    <Grid centered columns={2}>
+                        <Grid.Column width={4}>
+                            {linkedInUpdate}
+                            {imageUpdate}
+                        </Grid.Column>
+                        <Grid.Column width={12}>
+                            {zoomLinkUpdate}
+                            {timeAvailabilitiesUpdate}
+                            {topicAvailabilitiesUpdate}
+                            {interestsUpdate}
+                        </Grid.Column>
+                    </Grid>
+                
                 </Card.Content>
+                </>
             )
         } else {
             canUpdate = <div />
@@ -238,6 +322,17 @@ export default class AlumniProfile extends Component {
                     <Card.Description>Location: {(details.city && details.country) ? `${details.city} (${details.country})` : 'Unavailable'}</Card.Description>
                     <Card.Description>Company: {details.companyName || 'Unavailable'}</Card.Description>
                     
+                </Card.Content>
+                <Card.Content>
+                    <Card.Header>Interests</Card.Header>
+                    <Segment
+                        loading={this.state.removingInterest}
+                    >
+                        {details.interests && details.interests.length ?
+                        this.getInterests() :
+                        <span>No interests added.</span>
+                        }
+                    </Segment>
                 </Card.Content>
                 {canUpdate}
             </Card>

--- a/client/src/components/AlumniProfile.js
+++ b/client/src/components/AlumniProfile.js
@@ -187,7 +187,7 @@ export default class AlumniProfile extends Component {
         const imageUpdate = (
             <>
             <Button
-                style={{'margin': '2px'}}
+                style={{'margin-right': '2px'}}
                 floated="left"
                 basic
                 color="blue"
@@ -206,7 +206,7 @@ export default class AlumniProfile extends Component {
         const timeAvailabilitiesUpdate = (
             <>
             <Button
-                style={{'margin': '2px'}}
+                style={{'margin-right': '5px'}}
                 floated='right'
                 basic
                 color="blue"
@@ -225,9 +225,9 @@ export default class AlumniProfile extends Component {
         const topicAvailabilitiesUpdate = (
             <>
             <Button
-                style={{'margin': '2px'}}
+                primary
+                style={{'margin-left': '2px'}}
                 floated='right'
-                basic
                 color="blue"
                 onClick={this.openTopicPreferencesModal}
             >
@@ -244,9 +244,9 @@ export default class AlumniProfile extends Component {
         const zoomLinkUpdate = (
             <>
              <Button
-                style={{'margin': '2px'}}
+                primary
+                style={{'margin-right': '5px'}}
                 floated='right'
-                basic
                 color="blue"
                 onClick={this.openZoomUpdateModal}
             >
@@ -264,7 +264,7 @@ export default class AlumniProfile extends Component {
         const interestsUpdate = (
             <>
             <Button
-                style={{'margin': '2px'}}
+                style={{'margin-left': '2px'}}
                 floated='right'
                 basic
                 color="blue"
@@ -285,16 +285,24 @@ export default class AlumniProfile extends Component {
             canUpdate = (
                 <>
                 <Card.Content extra>
-                    <Grid centered columns={2}>
-                        <Grid.Column width={4}>
-                            {linkedInUpdate}
-                            {imageUpdate}
+                    <Grid centered columns={3}>
+                        <Grid.Column width={6}>
+                            <Button.Group vertical>
+                                {linkedInUpdate}
+                                {imageUpdate}
+                            </Button.Group>
                         </Grid.Column>
-                        <Grid.Column width={12}>
-                            {zoomLinkUpdate}
-                            {timeAvailabilitiesUpdate}
-                            {topicAvailabilitiesUpdate}
-                            {interestsUpdate}
+                        <Grid.Column width={5}>
+                            <Button.Group vertical>
+                                {zoomLinkUpdate}
+                                {timeAvailabilitiesUpdate}
+                            </Button.Group>
+                        </Grid.Column>
+                        <Grid.Column width={5}>
+                            <Button.Group vertical>
+                                {topicAvailabilitiesUpdate}
+                                {interestsUpdate}
+                            </Button.Group>
                         </Grid.Column>
                     </Grid>
                 

--- a/client/src/components/InterestsUpdateModal.js
+++ b/client/src/components/InterestsUpdateModal.js
@@ -1,0 +1,125 @@
+import React, { Component } from 'react';
+import { Button, Modal, Step } from 'semantic-ui-react';
+import PooledMultiSelectDropdown from "./PooledMultiSelectDropdown"
+import swal from "sweetalert";
+import { makeCall } from "../apis";
+
+/*
+props:
+    - modalOpen: boolean
+    - closeModal: ()
+    - interests: []
+    - id
+*/
+export default class InterestsUpdateModal extends Component {
+    constructor(props){
+        super(props)
+        this.state = {
+            existingInterests: [],
+            newInterests: [],
+            submitting: false
+        }
+        this.handleChange = this.handleChange.bind(this)
+        this.getInterestsInput = this.getInterestsInput.bind(this)
+        this.submit = this.submit.bind(this)
+    }
+
+    handleChange(e) {
+        e.preventDefault();
+        let change = {}
+        change[e.target.name] = e.target.value
+        this.setState(change)
+    }
+
+    submit(e) {
+        e.preventDefault()
+        this.setState({
+            submitting: true
+        }, async () => {
+            let payload = {
+                newInterests: this.state.newInterests,
+                existingInterests: this.state.existingInterests
+            }
+            try {
+                const result = await makeCall(payload, `/alumni/interests/add/${this.props.id}`, 'patch')
+                if (!result || result.error) {
+                    this.setState({
+                        submitting: false
+                    }, () => {
+                        swal({
+                            title: "Error!",
+                            text: "There was an error adding your interests, please try again.",
+                            icon: "error",
+                        });
+                    })
+                } else {
+                    this.setState({
+                        submitting: false
+                    }, () => {
+                        swal({
+                            title: "Done!",
+                            text: "Your interests have been successfully added!",
+                            icon: "success",
+                        }).then(() => {
+                            this.props.closeModal();
+                        })
+                    })
+                    
+                }
+            } catch (e) {
+                this.setState({
+                    submitting: false
+                }, () => {
+                    console.log("Error: InterestsUpdateModal#submit", e);
+                })
+            }
+        })
+    }
+
+    getInterestsInput(selection) {
+        this.setState({
+            existingInterests: selection.old,
+            newInterests: selection.new,
+        })
+    }
+
+    render() {
+        return (
+            <Modal
+                open={this.props.modalOpen}
+            >
+                <Modal.Header>Update your interests</Modal.Header>
+                <Modal.Content>
+                <Step.Group>
+                <Step>
+                    <Step.Title>
+                        Select your interests, professional or otherwise
+                    </Step.Title>
+                    <Step.Description>
+                        (Only add new entries if they don't exist in dropdown!)
+                    </Step.Description>
+                </Step>
+                </Step.Group>
+                <PooledMultiSelectDropdown
+                    endpoint={'/drop/interests'}
+                    dataType={'Interest'}
+                    getInputs={this.getInterestsInput}
+                    allowAddition={true}
+                />
+                </Modal.Content>
+                <Modal.Actions>
+                    <Button
+                        primary
+                        disabled={!this.state.newInterests.length && !this.state.existingInterests.length}
+                        onClick={this.submit}
+                    >
+                        Submit
+                    </Button>
+                    <Button onClick={this.props.closeModal}>
+                        Close
+                    </Button>
+                </Modal.Actions>
+            </Modal>
+        )
+    }
+}

--- a/client/src/components/LinkedInUpdate.js
+++ b/client/src/components/LinkedInUpdate.js
@@ -21,7 +21,11 @@ export default class LinkedInUpdate extends React.Component {
 
     render() {
       return (
-        <Button primary onClick={this.fetchFromLinkedIn}>
+        <Button
+          primary
+          onClick={this.fetchFromLinkedIn}
+          style={{'margin': '2px'}}  
+        >
             Fetch Photo from LinkedIn
         </Button>
       )

--- a/client/src/components/LinkedInUpdate.js
+++ b/client/src/components/LinkedInUpdate.js
@@ -24,7 +24,7 @@ export default class LinkedInUpdate extends React.Component {
         <Button
           primary
           onClick={this.fetchFromLinkedIn}
-          style={{'margin': '2px'}}  
+          style={{'margin-right': '2px'}}  
         >
             Fetch Photo from LinkedIn
         </Button>


### PR DESCRIPTION
Added the ability to add and delete interests from alumni profile, when not in `isViewOnly` mode.
Clicking on `x` next to interest pill (label) make a call to dissociate interest from alumni and refreshes profile.
Added guard logic that prevents any interest addition from failing when alumni accidentally add a custom interest that already exists.

![image](https://user-images.githubusercontent.com/31665569/84221586-a140ef80-aaa3-11ea-9001-5ec3742c9cae.png)

![image](https://user-images.githubusercontent.com/31665569/84221649-c03f8180-aaa3-11ea-8cf2-15be4767d71d.png)

