### PR TITLE
Request Modal updates

### DIFF
--- a/client/src/components/RequestModal.js
+++ b/client/src/components/RequestModal.js
@@ -93,7 +93,7 @@ export default class RequestModal extends Component {
             }
         }
         availabilityOptions = await availabilityOptions.sort((a, b) => {
-            let valueA = (dayOptions.indexOf(a.day) * 10000) + a.time
+            let valueA = (10000 * dayOptions.indexOf(a.day)) + parseInt(a.time)
             let valueB = (10000 * dayOptions.indexOf(b.day)) + parseInt(b.time)
             return valueA - valueB
         })

--- a/client/src/components/RequestModal.js
+++ b/client/src/components/RequestModal.js
@@ -30,6 +30,7 @@ export const timeSlotOptions = [
     '10pm - 11pm',
     '11pm - 12am'
 ]
+const dayOptions = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
 
 
 /*
@@ -67,20 +68,35 @@ export default class RequestModal extends Component {
         this.createTopicOptions(this.state.alumni.topics)
     }
 
+    // Gets availability slots, adjusts for timezone, removes existing
+    // confirmed requests, and then sorts them
     async createAvailabilityOptions(availabilities) {
         let adjustedAvailabilities = await makeCall({availabilities: availabilities,
                                                     offset: parseInt(this.state.timeOffset)}, 
                                                     '/request/applyRequesterTimezone', 
                                                     'patch')
+        let confirmedTimes = await makeCall({}, '/request/getConfirmed/'+this.state.alumni._id+'/'+this.state.timeOffset, 'get')
+        confirmedTimes = confirmedTimes.confirmed.map(confirmedRequest => {
+            return confirmedRequest.time[0].id
+        })
         let availabilityOptions = []
         for (let option of adjustedAvailabilities.availabilities) {
-            let readableOption = option.day + ', ' + timeSlotOptions[(option.time/100)]
-            availabilityOptions.push({
-                key: option.id,
-                text: readableOption,
-                value: option.id,
-            })
+            if (!confirmedTimes.includes(option.id)) {
+                let readableOption = option.day + ', ' + timeSlotOptions[(option.time/100)]
+                availabilityOptions.push({
+                    day: option.day,
+                    time: option.time,
+                    key: option.id,
+                    text: readableOption,
+                    value: option.id,
+                })
+            }
         }
+        availabilityOptions = await availabilityOptions.sort((a, b) => {
+            let valueA = (dayOptions.indexOf(a.day) * 10000) + a.time
+            let valueB = (10000 * dayOptions.indexOf(b.day)) + parseInt(b.time)
+            return valueA - valueB
+        })
         this.setState({availabilityOptions: availabilityOptions})
     }
 

--- a/client/src/components/RequestModal.js
+++ b/client/src/components/RequestModal.js
@@ -92,7 +92,7 @@ export default class RequestModal extends Component {
                 })
             }
         }
-        availabilityOptions = await availabilityOptions.sort((a, b) => {
+        availabilityOptions = availabilityOptions.sort((a, b) => {
             let valueA = (10000 * dayOptions.indexOf(a.day)) + parseInt(a.time)
             let valueB = (10000 * dayOptions.indexOf(b.day)) + parseInt(b.time)
             return valueA - valueB

--- a/server/routes/requests.js
+++ b/server/routes/requests.js
@@ -186,6 +186,19 @@ router.patch('/updateScheduling/:id/:role/:timeOffset', async (req, res, next) =
     }
 })
 
-
+router.get('/getConfirmed/:id/:timeOffset', async (req, res, next) => {
+    let alumniId = req.params.id;
+    let timeOffset = parseInt(req.params.timeOffset)
+    try {
+        const dbData = await requestSchema.find({mentor: alumniId, status: 'Confirmed'})
+        for (let request of dbData) {
+            request.time = await timezoneHelpers.applyTimezone(request.time, timeOffset)
+        }
+        res.json({'confirmed' : dbData});
+    } catch (e) {
+        console.log('getConfirmed error: ' + e)
+        res.status(500).send({message: 'getConfirmed error: ' + e})
+    }
+})
 
 module.exports = router;


### PR DESCRIPTION
## Frontend:
#### Request Modal:
In createAvailabilityOptions, fetches the confirmed times to prevent students from requesting an unavailable time slot
Minor QoL fix: Availabilities are now sorted Monday-Sunday, 12am to 11pm

## Backend:
#### requests.js
New route:
`GET` /request/getConfirmed/:id/:timeOffset
returns a list of confirmed requests after applying the correct timezone