### PR TITLE
Responsive Navbar, other minor changes

### DIFF
--- a/client/src/components/AlumniDirectory.js
+++ b/client/src/components/AlumniDirectory.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Card, Image, Search, Pagination, Grid, Segment, Button, Dropdown } from 'semantic-ui-react'
+import { Card, Image, Search, Pagination, Grid, Segment, Button, Dropdown, Responsive } from 'semantic-ui-react'
 import { makeCall } from '../apis';
 import RequestModal from './RequestModal'
 
@@ -327,9 +327,16 @@ export default class AlumniDirectory extends Component {
                 <Grid.Row stretched>
                     <Grid.Column>
                         <Segment>
-                            <Pagination
+                            <Responsive as={Pagination} minWidth={726}
                                 activePage={activePage}
                                 totalPages={totalPages}
+                                onPageChange={this.handlePaginationChange}
+                            />
+                            <Responsive as={Pagination} maxWidth={726}
+                                activePage={activePage}
+                                totalPages={totalPages}
+                                siblingRange={0}
+                                boundaryRange={0}
                                 onPageChange={this.handlePaginationChange}
                             />
                         </Segment>

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -26,7 +26,7 @@ export default class Navbar extends Component {
     constructor(props) {
         super(props)
         this.state = {
-            visible: false
+            sidebarVisible: false
         }
         this.renderMenuItems = this.renderMenuItems.bind(this);
         this.handleOffsetChange = this.handleOffsetChange.bind(this);
@@ -34,7 +34,7 @@ export default class Navbar extends Component {
     }
 
     componentWillMount() {
-        this.setState({visible: false})
+        this.setState({sidebarVisible: false})
     }
 
     renderMenuItems(items, activeItem) {
@@ -57,9 +57,8 @@ export default class Navbar extends Component {
         window.location.reload()
     }
 
-    handleClick() {
-        let menuVisible = this.state.visible
-        this.setState({visible: !menuVisible})
+    async handleClick() {
+        this.setState({sidebarVisible: !this.state.sidebarVisible})
     }
 
     render() {
@@ -83,7 +82,7 @@ export default class Navbar extends Component {
                     icon='labeled'
                     inverted
                     vertical
-                    visible={this.state.visible}
+                    visible={this.state.sidebarVisible}
                     width='thin'
                 >
                     {this.renderMenuItems(navItems, activeItem)}

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Menu } from 'semantic-ui-react'
+import { Menu, Responsive, Sidebar, Icon, Button, MenuItem } from 'semantic-ui-react'
 import { Link } from 'react-router-dom'
 import  TimeZoneDropdown  from './TimeZoneDropdown'
 
@@ -25,9 +25,18 @@ import  TimeZoneDropdown  from './TimeZoneDropdown'
 export default class Navbar extends Component {
     constructor(props) {
         super(props)
+        this.state = {
+            visible: false
+        }
         this.renderMenuItems = this.renderMenuItems.bind(this);
         this.handleOffsetChange = this.handleOffsetChange.bind(this);
+        this.handleClick = this.handleClick.bind(this)
     }
+
+    componentWillMount() {
+        this.setState({visible: false})
+    }
+
     renderMenuItems(items, activeItem) {
         return items && items.map( item => {
             return (
@@ -48,12 +57,17 @@ export default class Navbar extends Component {
         window.location.reload()
     }
 
+    handleClick() {
+        let menuVisible = this.state.visible
+        this.setState({visible: !menuVisible})
+    }
+
     render() {
         const { navItems, activeItem, role } = this.props
         return (
-            <Menu stackable>
+            <>
+            <Responsive as={Menu} minWidth={726}>
                 {this.renderMenuItems(navItems, activeItem)}
-                
                 {this.props.timezoneActive &&
                     <TimeZoneDropdown
                         userDetails={this.props.userDetails}
@@ -61,7 +75,30 @@ export default class Navbar extends Component {
                         liftTimezone={this.handleOffsetChange}
                     />
                 }
-            </Menu>
+            </Responsive>
+            <Responsive maxWidth={726}>
+                <Sidebar
+                    as={Menu}
+                    animation='overlay'
+                    icon='labeled'
+                    inverted
+                    vertical
+                    visible={this.state.visible}
+                    width='thin'
+                >
+                    {this.renderMenuItems(navItems, activeItem)}
+                    {this.props.timezoneActive &&
+                        <TimeZoneDropdown
+                            userDetails={this.props.userDetails}
+                            userRole={role}
+                            liftTimezone={this.handleOffsetChange}
+                        />
+                    }
+                    <Button icon='close' as={Menu.Item} onClick={this.handleClick}/>
+                </Sidebar>
+                <Button icon='bars' onClick={this.handleClick} fluid style={{'margin-bottom': '18px'}}/>
+            </Responsive>
+            </>
         )
     }
 }

--- a/client/src/components/Signup.js
+++ b/client/src/components/Signup.js
@@ -8,7 +8,9 @@ import CollegeSelectionModal from './CollegeSelectionModal';
 import CareerAndInterestsModal from './CareerAndInterestsModal';
 
 let fieldStyle = {
-    width: '100%',
+    width: '90%',
+    'margin-left': 'auto',
+    'margin-right': 'auto'
 }
 let messageStyle = {
     padding: '20px',
@@ -484,7 +486,7 @@ export default class Signup extends React.Component {
                         </Button>
                     </Grid.Row>
                     <Grid.Row centered>
-                    <Form onSubmit={this.handleSubmit}>
+                    <Form onSubmit={this.handleSubmit} widths={'equal'}>
                         <Form.Field
                             type="email"
                             required={true}
@@ -523,20 +525,19 @@ export default class Signup extends React.Component {
                             <label>Name</label>
                             <input placeholder='Name' name="name" onChange={this.handleChange} />
                         </Form.Field>
-                        <Form.Field
+                        <Form.Dropdown
+                            label={'High School'}
                             required={true}
+                            style={fieldStyle}
+                            basic
+                            placeholder={'Select your high school network'}
+                            search
+                            selection
+                            options={this.state.schoolOptions}
+                            value={this.state.value}
+                            onChange={this.handleSchoolSelection}
                         >
-                            <label>High School</label>
-                            <Dropdown
-                                style={{ 'margin': '5px', 'width': '80%'}}
-                                placeholder={'Select your high school network'}
-                                search
-                                selection
-                                options={this.state.schoolOptions}
-                                value={this.state.value}
-                                onChange={this.handleSchoolSelection}
-                            />
-                        </Form.Field>
+                        </Form.Dropdown>
                         {this.props.isAlumni ? 
                             this.getAlumniFields() :
                             this.getStudentFields()

--- a/client/src/screens/Register.js
+++ b/client/src/screens/Register.js
@@ -18,19 +18,7 @@ export default class Register extends React.Component {
                 />
             </Grid.Row>
             <Grid.Row>
-                <Button centered onClick={
-                    (e) => {
-                        e.preventDefault(); props.history.goBack()
-                        }
-                    }
-                >
-                    Back
-                </Button>
-            </Grid.Row>
-            <Grid.Row>
-                <Button.Group size='massive' style={{
-                    'padding': '200px 0 100px 0'
-                }}>
+                <Button.Group size='massive'>
                     <Link to={`${match.url}/student`}>
                         <Button 
                             color='yellow'
@@ -47,6 +35,21 @@ export default class Register extends React.Component {
                         </Button>
                     </Link>
                 </Button.Group>
+            </Grid.Row>
+            <Grid.Row>
+                <Button centered style={{
+                    'position': 'relative',
+                    'bottom': '0',
+                    'margin': '200px 0 100px 0'
+                }} 
+                onClick={
+                    (e) => {
+                        e.preventDefault(); props.history.goBack()
+                        }
+                    }
+                >
+                    Back
+                </Button>
             </Grid.Row>
         </Grid>
         return (


### PR DESCRIPTION
Now uses responsive elements from react for bulkier elements of our design
Also made small tweaks to signup pages to clean up mobile formatting
Other areas seem mostly ok with current stackable setup and mobile friendly button groups

New registration page
<img width="345" alt="Screen Shot 2020-06-15 at 11 53 42 PM" src="https://user-images.githubusercontent.com/54961598/84730307-d5188b00-af63-11ea-8ac4-970ef555f560.png">

Signup page
<img width="335" alt="Screen Shot 2020-06-15 at 11 53 53 PM" src="https://user-images.githubusercontent.com/54961598/84730310-d649b800-af63-11ea-97b7-f020740d4afe.png">

Responsive Pagination
<img width="360" alt="Screen Shot 2020-06-15 at 11 53 17 PM" src="https://user-images.githubusercontent.com/54961598/84730315-d9dd3f00-af63-11ea-8d9b-184b71500fd4.png">

Menu button
<img width="381" alt="Screen Shot 2020-06-15 at 11 42 47 PM" src="https://user-images.githubusercontent.com/54961598/84730319-dba70280-af63-11ea-9369-065f7f2c19d4.png">

Menu Sidebar
<img width="380" alt="Screen Shot 2020-06-15 at 11 43 03 PM" src="https://user-images.githubusercontent.com/54961598/84730321-dd70c600-af63-11ea-9169-93aec4a3242f.png">
