### PR TITLE
Added JWT cookie authentication for sensitive end-points

### DIFF
--- a/server/routes/alumni.js
+++ b/server/routes/alumni.js
@@ -162,7 +162,7 @@ router.post('/', async (req, res, next) => {
     }
 });
 
-router.get('/all/:schoolId', async (req, res, next) => {
+router.get('/all/:schoolId', passport.authenticate('jwt', {session: false}), async (req, res, next) => {
     try {
         let alumni = await alumniSchema.find({school: req.params.schoolId})
         res.json({'alumni' : alumni});
@@ -173,7 +173,7 @@ router.get('/all/:schoolId', async (req, res, next) => {
 });
 
 
-router.get('/unapproved/:schoolId', async(req, res, next) => {
+router.get('/unapproved/:schoolId', passport.authenticate('jwt', {session: false}), async(req, res, next) => {
     try {
         const dbData = await alumniSchema.find({approved: false, school: req.params.schoolId})
         res.json({'unapproved': dbData})
@@ -183,7 +183,7 @@ router.get('/unapproved/:schoolId', async(req, res, next) => {
     }
 });
 
-router.post('/approve/', async(req, res, next) => {
+router.post('/approve/', passport.authenticate('jwt', {session: false}), async(req, res, next) => {
     try {
         const alumni = await alumniSchema.findOne({_id: req.body.id})
         alumni.approved = true
@@ -197,7 +197,7 @@ router.post('/approve/', async(req, res, next) => {
     }
 });
 
-router.get('/one/:id', async (req, res, next) => {
+router.get('/one/:id', passport.authenticate('jwt', {session: false}), async (req, res, next) => {
     try {
         let alumnus = await alumniSchema.findOne({_id: req.params.id})
         alumnus.availabilities = timezoneHelpers.applyTimezone(alumnus.availabilities, alumnus.timeZone)
@@ -213,7 +213,7 @@ router.get('/topicOptions', async (req, res, next) => {
     res.status(200).send({topics: preloadedTopics})
 })
 
-router.patch('/timePreferences/:id', async (req, res, next) => {
+router.patch('/timePreferences/:id', passport.authenticate('jwt', {session: false}), async (req, res, next) => {
     try {
         const alumni = await alumniSchema.findOne({_id: req.params.id})
         const timezoneAgnosticPreferences = timezoneHelpers.stripTimezone(req.body.timePreferences, alumni.timeZone || 0)
@@ -226,7 +226,7 @@ router.patch('/timePreferences/:id', async (req, res, next) => {
     }
 });
 
-router.patch('/topicPreferences/:id', async (req, res, next) => {
+router.patch('/topicPreferences/:id', passport.authenticate('jwt', {session: false}), async (req, res, next) => {
     try {
         const alumni = await alumniSchema.findOne({_id: req.params.id})
         alumni.topics = req.body.topicPreferences
@@ -238,7 +238,7 @@ router.patch('/topicPreferences/:id', async (req, res, next) => {
     }
 })
 
-router.patch('/zoomLink/:id', async (req, res, next) => {
+router.patch('/zoomLink/:id', passport.authenticate('jwt', {session: false}), async (req, res, next) => {
     try {
         const alumni = await alumniSchema.findOne({_id: req.params.id})
         alumni.zoomLink = req.body.zoomLink
@@ -250,7 +250,7 @@ router.patch('/zoomLink/:id', async (req, res, next) => {
     }
 })
 
-router.patch('/interests/remove/:id', async (req, res, next) => {
+router.patch('/interests/remove/:id', passport.authenticate('jwt', {session: false}), async (req, res, next) => {
     try {
         const alumni = await alumniSchema.findOne({_id: req.params.id})
         alumni.interests = alumni.interests.filter(interest => interest._id.toString() !== req.body.interestIdToRemove)
@@ -262,7 +262,7 @@ router.patch('/interests/remove/:id', async (req, res, next) => {
     }
 })
 
-router.patch('/interests/add/:id', async (req, res, next) => {
+router.patch('/interests/add/:id', passport.authenticate('jwt', {session: false}), async (req, res, next) => {
     try {
         let alumni = await alumniSchema.findOne({_id: req.params.id})
         const existingInterests = req.body.existingInterests
@@ -278,7 +278,7 @@ router.patch('/interests/add/:id', async (req, res, next) => {
     }
 })
 
-router.patch('/collegeAndCareer/update/:id', async (req, res, next) => {
+router.patch('/collegeAndCareer/update/:id', passport.authenticate('jwt', {session: false}), async (req, res, next) => {
     try {
         let alumni = await alumniSchema.findOne({_id: req.params.id})
         let existingJobTitleId = req.body.existingJobTitleId
@@ -342,7 +342,7 @@ router.patch('/collegeAndCareer/update/:id', async (req, res, next) => {
     }
 })
 
-router.patch('/location/update/:id', async (req, res, next) => {
+router.patch('/location/update/:id', passport.authenticate('jwt', {session: false}), async (req, res, next) => {
     try {
         let alumni = await alumniSchema.findOne({_id: req.params.id})
         alumni.country = req.body.country

--- a/server/routes/alumni.js
+++ b/server/routes/alumni.js
@@ -2,6 +2,7 @@ var express = require('express');
 var router = express.Router();
 var crypto = require('crypto-random-string');
 var bcrypt = require('bcrypt');
+var passport = require("passport");
 var userSchema = require('../models/userSchema');
 var alumniSchema = require('../models/alumniSchema');
 var collegeSchema = require('../models/collegeSchema');

--- a/server/routes/dropdown.js
+++ b/server/routes/dropdown.js
@@ -1,4 +1,5 @@
 var express = require('express');
+var passport = require("passport");
 var router = express.Router();
 var schoolSchema = require('../models/schoolSchema');
 var collegeSchema = require('../models/collegeSchema');
@@ -25,7 +26,7 @@ router.get('/countries/', async (req, res, next) => {
     }
 });
 
-router.get('/schoolsOptions', passport.authenticate('jwt', {session: false}), async (req, res) => {
+router.get('/schoolsOptions', async (req, res) => {
     try {
       let schools = await schoolSchema.find()
       let schoolOptions = schools.map( school => {
@@ -42,7 +43,7 @@ router.get('/schoolsOptions', passport.authenticate('jwt', {session: false}), as
     }
 })
 
-router.get('/jobTitles', passport.authenticate('jwt', {session: false}), async (req, res) => {
+router.get('/jobTitles', async (req, res) => {
   try {
     let jobTitles = await jobTitleSchema.find()
     let jobTitlesOptions = jobTitles.map( job => {
@@ -59,7 +60,7 @@ router.get('/jobTitles', passport.authenticate('jwt', {session: false}), async (
   }
 })
 
-router.get('/companies', passport.authenticate('jwt', {session: false}), async (req, res) => {
+router.get('/companies', async (req, res) => {
   try {
     let companies = await companySchema.find()
     let companiesOptions = companies.map( company => {
@@ -76,7 +77,7 @@ router.get('/companies', passport.authenticate('jwt', {session: false}), async (
   }
 })
 
-router.get('/interests', passport.authenticate('jwt', {session: false}), async (req, res) => {
+router.get('/interests', async (req, res) => {
   try {
     let interests = await interestsSchema.find()
     let interestsOptions = interests.map( interest => {
@@ -93,7 +94,7 @@ router.get('/interests', passport.authenticate('jwt', {session: false}), async (
   }
 })
 
-router.get('/colleges/:country', passport.authenticate('jwt', {session: false}), async (req, res) => {
+router.get('/colleges/:country', async (req, res) => {
   try {
     let country = req.params.country
     let colleges = await collegeSchema.find({country: country})

--- a/server/routes/dropdown.js
+++ b/server/routes/dropdown.js
@@ -25,7 +25,7 @@ router.get('/countries/', async (req, res, next) => {
     }
 });
 
-router.get('/schoolsOptions', async (req, res) => {
+router.get('/schoolsOptions', passport.authenticate('jwt', {session: false}), async (req, res) => {
     try {
       let schools = await schoolSchema.find()
       let schoolOptions = schools.map( school => {
@@ -42,7 +42,7 @@ router.get('/schoolsOptions', async (req, res) => {
     }
 })
 
-router.get('/jobTitles', async (req, res) => {
+router.get('/jobTitles', passport.authenticate('jwt', {session: false}), async (req, res) => {
   try {
     let jobTitles = await jobTitleSchema.find()
     let jobTitlesOptions = jobTitles.map( job => {
@@ -59,7 +59,7 @@ router.get('/jobTitles', async (req, res) => {
   }
 })
 
-router.get('/companies', async (req, res) => {
+router.get('/companies', passport.authenticate('jwt', {session: false}), async (req, res) => {
   try {
     let companies = await companySchema.find()
     let companiesOptions = companies.map( company => {
@@ -76,7 +76,7 @@ router.get('/companies', async (req, res) => {
   }
 })
 
-router.get('/interests', async (req, res) => {
+router.get('/interests', passport.authenticate('jwt', {session: false}), async (req, res) => {
   try {
     let interests = await interestsSchema.find()
     let interestsOptions = interests.map( interest => {
@@ -93,7 +93,7 @@ router.get('/interests', async (req, res) => {
   }
 })
 
-router.get('/colleges/:country', async (req, res) => {
+router.get('/colleges/:country', passport.authenticate('jwt', {session: false}), async (req, res) => {
   try {
     let country = req.params.country
     let colleges = await collegeSchema.find({country: country})

--- a/server/routes/image.js
+++ b/server/routes/image.js
@@ -34,7 +34,7 @@ const params = {
 return await s3.upload(params).promise();
 };
 
-router.post('/alumni/:alumniId', async (req, res, next) => {
+router.post('/alumni/:alumniId', passport.authenticate('jwt', {session: false}), async (req, res, next) => {
     try {
         const form = new multiparty.Form();
         form.parse(req, async (error, fields, files) => {

--- a/server/routes/image.js
+++ b/server/routes/image.js
@@ -1,4 +1,5 @@
 var express = require('express');
+var passport = require("passport");
 var router = express.Router();
 var AWS = require('aws-sdk');
 var fs = require('fs');
@@ -59,7 +60,7 @@ router.post('/alumni/:alumniId', passport.authenticate('jwt', {session: false}),
     }
 });
 
-router.post('/student/:studentId', async (req, res, next) => {
+router.post('/student/:studentId', passport.authenticate('jwt', {session: false}), async (req, res, next) => {
     try {
         const form = new multiparty.Form();
         form.parse(req, async (error, fields, files) => {

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -109,7 +109,7 @@ router.get('/verification/:email/:verificationToken', async (req, res, next) => 
 
 });
 
-router.post('/password/change', async (req, res, next) => {
+router.post('/password/change', passport.authenticate('jwt', {session: false}), async (req, res, next) => {
   const password = req.body.newPassword
   const email = req.body.email
   const passwordHash = await bcrypt.hash(password, HASH_COST);
@@ -122,7 +122,7 @@ router.post('/password/change', async (req, res, next) => {
   }
 });
 
-router.post('/password/forgot', async (req, res, next) => {
+router.post('/password/forgot', passport.authenticate('jwt', {session: false}), async (req, res, next) => {
   const email = req.body.email
   const newTempPass = crypto({length: 16});
   try{
@@ -139,7 +139,7 @@ router.get('/isLoggedIn', passport.authenticate('jwt', {session: false}), (req, 
   res.json({message: "You have a fresh cookie!"});
 });
 
-router.patch('/changeTimeZone/', async (req, res, next) => {
+router.patch('/changeTimeZone/', passport.authenticate('jwt', {session: false}), async (req, res, next) => {
   let id = req.body.id
   let role = req.body.role
   let newTimeZone = req.body.timeZone
@@ -185,7 +185,7 @@ function requestProfile(token) {
 }
 
 // end-point configured as callback for LinkedIn App
-router.get('/linkedin', (req, res, next) => {
+router.get('/linkedin', passport.authenticate('jwt', {session: false}), (req, res, next) => {
   // state is the email address of member
   requestAccessToken(req.query.code, req.query.state)
   .then((response) => {

--- a/server/routes/requests.js
+++ b/server/routes/requests.js
@@ -1,4 +1,5 @@
 var express = require('express');
+var passport = require("passport");
 var router = express.Router();
 var alumniSchema = require('../models/alumniSchema');
 var studentSchema = require('../models/studentSchema');

--- a/server/routes/requests.js
+++ b/server/routes/requests.js
@@ -12,7 +12,7 @@ router.get('/', async (req, res, next) => {
     })
 })
 
-router.patch('/applyRequesterTimezone', async (req, res, next) => {
+router.patch('/applyRequesterTimezone', passport.authenticate('jwt', {session: false}), async (req, res, next) => {
     try {
         const agnosticAvailabilities = req.body.availabilities;
         const timezone = req.body.offset
@@ -28,7 +28,7 @@ router.patch('/applyRequesterTimezone', async (req, res, next) => {
     }
 })
 
-router.post('/addRequest', async (req, res, next) => {
+router.post('/addRequest', passport.authenticate('jwt', {session: false}), async (req, res, next) => {
     try {
         const requesterId = req.body.requesterId;
         const requesterRole = req.body.requesterRole
@@ -74,7 +74,7 @@ router.post('/addRequest', async (req, res, next) => {
     }
 });
 
-router.patch('/updateRequest/:id/:timeOffset', async (req,res, next) => {
+router.patch('/updateRequest/:id/:timeOffset', passport.authenticate('jwt', {session: false}), async (req,res, next) => {
     let alumniId = req.params.id;
     let timeOffset = parseInt(req.params.timeOffset);
     let requestId = req.body.requestId;
@@ -106,7 +106,7 @@ router.patch('/updateRequest/:id/:timeOffset', async (req,res, next) => {
     }
 })
 
-router.get('/getRequests/:id/:timeOffset', async (req, res, next) => {
+router.get('/getRequests/:id/:timeOffset', passport.authenticate('jwt', {session: false}), async (req, res, next) => {
     let alumniId = req.params.id;
     let timeOffset = parseInt(req.params.timeOffset)
     let conditions = ['Awaiting Confirmation', 'Confirmed', 'Completed']
@@ -131,7 +131,7 @@ router.get('/getRequests/:id/:timeOffset', async (req, res, next) => {
     }
 })
 
-router.get('/getSchedulings/:id/:role/:timeOffset', async (req, res, next) => {
+router.get('/getSchedulings/:id/:role/:timeOffset', passport.authenticate('jwt', {session: false}), async (req, res, next) => {
     let requesterId = req.params.id;
     let requesterRole = req.params.role;
     let timeOffset = parseInt(req.params.timeOffset);
@@ -156,7 +156,7 @@ router.get('/getSchedulings/:id/:role/:timeOffset', async (req, res, next) => {
     }
 })
 
-router.patch('/updateScheduling/:id/:role/:timeOffset', async (req, res, next) => {
+router.patch('/updateScheduling/:id/:role/:timeOffset', passport.authenticate('jwt', {session: false}), async (req, res, next) => {
     let requesterId = req.params.id;
     let requesterRole = req.params.role;
     let timeOffset = parseInt(req.params.timeOffset);
@@ -186,7 +186,7 @@ router.patch('/updateScheduling/:id/:role/:timeOffset', async (req, res, next) =
     }
 })
 
-router.get('/getConfirmed/:id/:timeOffset', async (req, res, next) => {
+router.get('/getConfirmed/:id/:timeOffset', passport.authenticate('jwt', {session: false}), async (req, res, next) => {
     let alumniId = req.params.id;
     let timeOffset = parseInt(req.params.timeOffset)
     try {

--- a/server/routes/students.js
+++ b/server/routes/students.js
@@ -1,4 +1,5 @@
 var express = require('express');
+var passport = require("passport");
 var router = express.Router();
 var crypto = require('crypto-random-string');
 var bcrypt = require('bcrypt');

--- a/server/routes/students.js
+++ b/server/routes/students.js
@@ -69,7 +69,7 @@ router.post('/', async (req, res, next) => {
     }
 });
 
-router.get('/one/:id', async (req, res, next) => {
+router.get('/one/:id', passport.authenticate('jwt', {session: false}), async (req, res, next) => {
     try {
         const dbData = await studentSchema.findOne({_id: req.params.id})
         res.json({'result' : dbData});
@@ -79,7 +79,7 @@ router.get('/one/:id', async (req, res, next) => {
     }
 });
 
-router.get('/:studentId/moderator/:grade/unapproved', async (req, res, next) => {
+router.get('/:studentId/moderator/:grade/unapproved', passport.authenticate('jwt', {session: false}), async (req, res, next) => {
     try {
         if (await isModerator(req.params.studentId)) {
             let unapproved =  await studentSchema.find({approved: false, grade: parseInt(req.params.grade)})
@@ -93,7 +93,7 @@ router.get('/:studentId/moderator/:grade/unapproved', async (req, res, next) => 
     }
 });
 
-router.post('/approve', async(req, res, next) => {
+router.post('/approve', passport.authenticate('jwt', {session: false}), async(req, res, next) => {
     try {
         const student = await studentSchema.findOne({_id: req.body.id})
         student.approved = true

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -1,4 +1,5 @@
 var express = require('express');
+var passport = require("passport");
 var router = express.Router();
 var userSchema = require('../models/userSchema');
 require('mongoose').Promise = global.Promise

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -3,7 +3,7 @@ var router = express.Router();
 var userSchema = require('../models/userSchema');
 require('mongoose').Promise = global.Promise
 
-router.get('/:id', async (req, res, next) => {
+router.get('/:id', passport.authenticate('jwt', {session: false}), async (req, res, next) => {
     try {
         const dbData = await userSchema.findOne({_id: req.params.id})
         res.json({'result' : dbData});


### PR DESCRIPTION
Changes:
* Used passport.authenticate's JWT Strategy to ensure that users have a fresh cookie when making requests to sensitive end-points