### PR TITLE
Add and remove interests on Student Profile

### DIFF
--- a/client/src/components/AlumniProfile.js
+++ b/client/src/components/AlumniProfile.js
@@ -170,13 +170,13 @@ export default class AlumniProfile extends Component {
     }
     async removeInterest(e, interestIdToRemove) {
         e.preventDefault()
-        this.setState({removeInterest: true},
+        this.setState({removingInterest: true},
             async () => {
                 await makeCall({interestIdToRemove: interestIdToRemove}, `/alumni/interests/remove/${this.props.details._id}`, 'patch')
                 this.setState({
-                    removeInterest: true
+                    removingInterest: false
                 }, () =>
-                this.props.refreshProfile(ALUMNI, this.props.details._id)
+                    this.props.refreshProfile(ALUMNI, this.props.details._id)
                 )
             })
     }
@@ -306,6 +306,7 @@ export default class AlumniProfile extends Component {
                 Add Interests
             </Button>
             <InterestsUpdateModal
+                role={'alumni'}
                 modalOpen={this.state.interestsModalOpen}
                 closeModal={this.closeInterestsModal}
                 id={details._id}

--- a/client/src/components/InterestsUpdateModal.js
+++ b/client/src/components/InterestsUpdateModal.js
@@ -6,6 +6,7 @@ import { makeCall } from "../apis";
 
 /*
 props:
+    - role: string
     - modalOpen: boolean
     - closeModal: ()
     - interests: []
@@ -49,7 +50,7 @@ export default class InterestsUpdateModal extends Component {
                 existingInterests: this.state.existingInterests
             }
             try {
-                const result = await makeCall(payload, `/alumni/interests/add/${this.props.id}`, 'patch')
+                const result = await makeCall(payload, `/${this.props.role}/interests/add/${this.props.id}`, 'patch')
                 if (!result || result.error) {
                     this.setState({
                         submitting: false

--- a/server/models/studentSchema.js
+++ b/server/models/studentSchema.js
@@ -14,7 +14,8 @@ const studentSchema = new Schema(
     approved: {type: Boolean, default: false},
     school: {type: Schema.Types.ObjectId, ref: 'School', required: true},
     schoolLogo: {type: String, default:'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png'},
-    isModerator: {type: Boolean, default: false}
+    isModerator: {type: Boolean, default: false},
+    interests: {type: Array, required: false}
   }
 );
 

--- a/server/routes/alumni.js
+++ b/server/routes/alumni.js
@@ -15,7 +15,7 @@ require('mongoose').Promise = global.Promise
 
 const HASH_COST = 10;
 
-async function generateNewAndExistingInterests(existingInterests, newInterests) {
+const generateNewAndExistingInterests = async (existingInterests, newInterests) => {
     const existingInterestsIds = existingInterests.map(interest => interest.value).flat()
     let existingInterestsRecords = await interestsSchema.find().where('_id').in(existingInterestsIds).exec()
     // create interests added
@@ -29,13 +29,16 @@ async function generateNewAndExistingInterests(existingInterests, newInterests) 
                 })
                 await newInterestCreated.save()
                 existingInterestsRecords.push(newInterestCreated)
+            } else {
+                // user accidentally added an interest that already exists as a new interest
+                existingInterestsRecords.push(interestExists[0])
             }
         }
     }
     return existingInterestsRecords
 }
 
-function getUniqueInterests(allInterests) {
+const getUniqueInterests = (allInterests) => {
     let allUniqueNames = new Set()
     let uniqueInterests = []
     for (let i = 0; i < allInterests.length; i++) {
@@ -356,3 +359,5 @@ router.patch('/location/update/:id', async (req, res, next) => {
 })
 
 module.exports = router;
+module.exports.generateNewAndExistingInterests = generateNewAndExistingInterests
+module.exports.getUniqueInterests = getUniqueInterests

--- a/server/routes/students.js
+++ b/server/routes/students.js
@@ -6,6 +6,8 @@ var userSchema = require('../models/userSchema');
 var studentSchema = require('../models/studentSchema');
 var schoolSchema = require('../models/schoolSchema');
 var sendStudentVerificationEmail = require('../routes/helpers/emailHelpers').sendStudentVerificationEmail
+var generateNewAndExistingInterests = require("./alumni").generateNewAndExistingInterests
+var getUniqueInterests = require("./alumni").getUniqueInterests
 require('mongoose').Promise = global.Promise
 
 const HASH_COST = 10;
@@ -106,5 +108,33 @@ router.post('/approve', async(req, res, next) => {
         res.status(500).send({'error': e});
     }
 });
+
+router.patch('/interests/remove/:id', async (req, res, next) => {
+    try {
+        const student = await studentSchema.findOne({_id: req.params.id})
+        student.interests = student.interests.filter(interest => interest._id.toString() !== req.body.interestIdToRemove)
+        await student.save()
+        res.status(200).send({message: "Successfully removed student's interest"})
+    } catch (e) {
+        console.log("Error: student#interests/remove", e);
+        res.status(500).send({'error' : e});
+    }
+})
+
+router.patch('/interests/add/:id', async (req, res, next) => {
+    try {
+        let student = await studentSchema.findOne({_id: req.params.id})
+        const existingInterests = req.body.existingInterests
+        const newInterests = req.body.newInterests || []
+        let interestsToAdd = await generateNewAndExistingInterests(existingInterests, newInterests)
+
+        student.interests = getUniqueInterests([...student.interests, ...interestsToAdd])
+        await student.save()
+        res.status(200).send({message: "Successfully added student's interests"})
+    } catch (e) {
+        console.log("Error: student#interests/add", e);
+        res.status(500).send({'error' : e});
+    }
+})
 
 module.exports = router;


### PR DESCRIPTION
Changes:
* bug fix that prevented users from adding existing `interests` that were accidentally commited as new ones
* students can now add and remove interests, picking from same pool of interests as alumni

Screens:
![image](https://user-images.githubusercontent.com/31665569/85091363-db4d7800-b1ac-11ea-89a9-a4d1bc8a9ed4.png)
