### PR TITLE
News Feed Item for call confirmations

### DIFF
--- a/client/src/components/NewsFeed.js
+++ b/client/src/components/NewsFeed.js
@@ -47,6 +47,10 @@ export default class NewsFeed extends Component {
                     display.push(<Divider key={i}/>)
                     display.push(this.createNewStudentPost(feedItem))
                     break;
+                case 'Confirmed Meeting':
+                    display.push(<Divider key={i}/>)
+                    display.push(this.createCallConfirmedPost(feedItem))
+                    break;
                 default:
                     break;
             }
@@ -127,6 +131,73 @@ export default class NewsFeed extends Component {
                 </Feed.Content>
             </Feed.Event>
         )
+    }
+
+    /*
+     * EVENT: 'Call Confirmed'
+     * Display to: 'BOTH' or 'ALUMNI'
+     * Contains: Either 2 entries in alumni or 1 entry in alumni and 1 entry in students,
+     * supportData.topic,
+     * grade(if there is an entry in students),
+     * time (stored as string) ONLY
+     * On Click: Opens student/alumni profile modal 
+     */ 
+    createCallConfirmedPost(feedItem) {
+        try {
+            let mentorDetails
+            let menteeDetails
+            let alumniRequestingAlumni = !feedItem.students.length
+            if (alumniRequestingAlumni) {
+                // mentor is first entry in list
+                mentorDetails = feedItem.alumni[0]
+                menteeDetails = feedItem.alumni[1]
+            } else {
+                menteeDetails = feedItem.students[0]
+                mentorDetails = feedItem.alumni[0]
+            }
+            return(
+                <Feed.Event key={feedItem._id}>
+                    <Feed.Label>
+                        <Image src={mentorDetails.imageURL} />
+                    </Feed.Label>
+                    <Feed.Label>
+                        <Image src={menteeDetails.imageURL} />
+                    </Feed.Label>
+                    <Feed.Content>
+                        <Feed.Summary>
+                            <Modal closeIcon onClose={this.close} dimmer='blurring' trigger={
+                                <Feed.User>{mentorDetails.name} (Alumni)</Feed.User>
+                            }>
+                                <Header>
+                                    Details for {mentorDetails.name}
+                                </Header>
+                                <Modal.Content>
+                                    <AlumniProfile details={mentorDetails} isViewOnly={true} />
+                                </Modal.Content>
+                            </Modal>
+                            {` confirmed a call with `}
+                            <Modal closeIcon onClose={this.close} dimmer='blurring' trigger={
+                                <Feed.User>{menteeDetails.name} {alumniRequestingAlumni ? `(Alumni)` : `(Student)`}</Feed.User>
+                            }>
+                                <Header>
+                                    Details for {menteeDetails.name}
+                                </Header>
+                                <Modal.Content>
+                                    {
+                                        alumniRequestingAlumni ? 
+                                        <AlumniProfile details={menteeDetails} isViewOnly={true} /> :
+                                        <StudentProfile details={menteeDetails} isViewOnly={true} />
+                                    }
+                                </Modal.Content>
+                            </Modal> to discuss {feedItem.supportData && feedItem.supportData.topic}
+                                <Feed.Date>{feedItem.timeElapsed}</Feed.Date>
+                        </Feed.Summary>
+                    </Feed.Content>
+                </Feed.Event>
+            )
+        } catch (e) {
+            console.log("Error: NewsFeed#createCallConfirmedPost", e)
+        }
     }
     
     render() {

--- a/server/helpers/timezoneHelpers.js
+++ b/server/helpers/timezoneHelpers.js
@@ -58,6 +58,7 @@ const timezoneUtil = {
     stripTimezone: (timeSlots, timezone) => {
         if (timezone === 0) {
             timeSlots.map( timeSlot => {
+                timeSlot.id = `${timeSlot.day}-${(timeSlot.time).toString()}`
                 delete timeSlot.text
                 return timeSlot
             })
@@ -86,6 +87,7 @@ const timezoneUtil = {
     applyTimezone: (timeSlots, timezone) => {
         if (timezone === 0) {
             timeSlots.map( timeSlot => {
+                timeSlot.id = `${timeSlot.day}-${(timeSlot.time).toString()}`
                 delete timeSlot.text
                 return timeSlot
             })

--- a/server/models/newsSchema.js
+++ b/server/models/newsSchema.js
@@ -11,7 +11,8 @@ const newsSchema = new Schema(
         school: {type: Schema.Types.ObjectId, ref: 'School'},
         dateCreated: {type: Date, default: moment()}, 
         role: {type: String, default: 'BOTH', enum: ['BOTH', 'ALUMNI', 'STUDENT']},
-        grade: {type: Number, default: null}
+        grade: {type: Number, default: null},
+        supportData: {type: Object, required: false}
     }
 );
 


### PR DESCRIPTION
Changes:
* News Feed Item created when a call is confirmed
* Alumni are able to see all confirmed calls in their school network
* Students are able to see all confirmed calls from their grade

Screens:
As Alumni -> 
![image](https://user-images.githubusercontent.com/31665569/85203898-4fd00600-b2d6-11ea-8df6-e3a3666204a6.png)
(For some reason, the dateCreated was exactly the same or both these newsFeed Items)

As Student ->
![image](https://user-images.githubusercontent.com/31665569/85203937-87d74900-b2d6-11ea-8da1-971aeacae334.png)
