### PR TITLE
Fullstack/request feedback

### DIFF
--- a/client/src/components/RequestsView.js
+++ b/client/src/components/RequestsView.js
@@ -283,7 +283,7 @@ class RequestCards extends Component {
         } else if (this.props.activeSet === 'completed') {
             return(
                 <Button
-                    secondary
+                    color='teal'
                     requestId={request._id}
                     onClick={this.toggleFeedbackModal.bind(this)}
                 >

--- a/client/src/components/SchedulingsView.js
+++ b/client/src/components/SchedulingsView.js
@@ -263,7 +263,7 @@ class SchedulingCards extends Component {
         } else if (this.props.activeSet === 'completed') {
             return(
                 <Button
-                    secondary
+                    color='teal'
                     requestId={scheduling._id}
                     onClick={this.toggleFeedbackModal.bind(this)}
                 >

--- a/server/models/requestSchema.js
+++ b/server/models/requestSchema.js
@@ -18,14 +18,16 @@ const requestSchema = new Schema(
     zoomLink: {type: String},
     topic: {type: String, required: true},
     status: {type: String, 
-                enum: [ 'Awaiting Confirmation',
+                enum: [ 
+                        'Awaiting Confirmation',
                         'Confirmed',
                         'Completed',
-                        'Rejected',
-                        'Feedback Provided'
+                        'Rejected'
                       ]
             },
-    note: {type: String}
+    note: {type: String},
+    finalNote: {type: String},
+    feedback: {type: String}
   }
 );
 

--- a/server/routes/helpers/emailHelpers.js
+++ b/server/routes/helpers/emailHelpers.js
@@ -37,7 +37,7 @@ const sendAlumniVerificationEmail = async (to, token, schoolName) => {
     )
   )
   // console.log("Sending email with", emailObject)
-  // await sg.send(emailObject, true)
+  await sg.send(emailObject, true)
 }
 
 const sendStudentVerificationEmail = async (to, token, schoolName) => {
@@ -52,7 +52,7 @@ const sendStudentVerificationEmail = async (to, token, schoolName) => {
     )
   )
   // console.log("Sending email with", emailObject)
-  // await sg.send(emailObject, true)
+  await sg.send(emailObject, true)
 }
 
 const sendNewRequestEmail = async (to) => {
@@ -67,7 +67,7 @@ const sendNewRequestEmail = async (to) => {
     )
   )
   // console.log("Sending email with", emailObject)
-  // await sg.send(emailObject, true)
+  await sg.send(emailObject, true)
 }
 
 const sendRequestConfirmedEmail = async (menteeEmail, menteeName, menteeTime, mentorEmail, mentorName, mentorTime, topic) => {
@@ -92,8 +92,8 @@ const sendRequestConfirmedEmail = async (menteeEmail, menteeName, menteeTime, me
     )
   )
   // console.log("Sending email with", emailObject)
-  //await sg.send(emailObjectForMentee, true)
-  //await sg.send(emailObjectForMentor, true)
+  await sg.send(emailObjectForMentee, true)
+  await sg.send(emailObjectForMentor, true)
 }
 
 exports.sendTestEmail = sendTestEmail

--- a/server/routes/helpers/emailHelpers.js
+++ b/server/routes/helpers/emailHelpers.js
@@ -37,7 +37,7 @@ const sendAlumniVerificationEmail = async (to, token, schoolName) => {
     )
   )
   // console.log("Sending email with", emailObject)
-  await sg.send(emailObject, true)
+  // await sg.send(emailObject, true)
 }
 
 const sendStudentVerificationEmail = async (to, token, schoolName) => {
@@ -52,7 +52,7 @@ const sendStudentVerificationEmail = async (to, token, schoolName) => {
     )
   )
   // console.log("Sending email with", emailObject)
-  await sg.send(emailObject, true)
+  // await sg.send(emailObject, true)
 }
 
 const sendNewRequestEmail = async (to) => {
@@ -67,7 +67,7 @@ const sendNewRequestEmail = async (to) => {
     )
   )
   // console.log("Sending email with", emailObject)
-  await sg.send(emailObject, true)
+  // await sg.send(emailObject, true)
 }
 
 const sendRequestConfirmedEmail = async (menteeEmail, menteeName, menteeTime, mentorEmail, mentorName, mentorTime, topic) => {
@@ -92,8 +92,8 @@ const sendRequestConfirmedEmail = async (menteeEmail, menteeName, menteeTime, me
     )
   )
   // console.log("Sending email with", emailObject)
-  await sg.send(emailObjectForMentee, true)
-  await sg.send(emailObjectForMentor, true)
+  //await sg.send(emailObjectForMentee, true)
+  //await sg.send(emailObjectForMentor, true)
 }
 
 exports.sendTestEmail = sendTestEmail

--- a/server/routes/requests.js
+++ b/server/routes/requests.js
@@ -178,7 +178,7 @@ router.patch('/leaveFinalNote/:id/:timeOffset', passport.authenticate('jwt', {se
         for (let status of conditions) {
             const dbData = await requestSchema.find({mentor: alumniId, status: status})
             for (let request of dbData) {
-                request.time = await timezoneHelpers.applyTimezone(request.time, timeOffset)
+                request.time = timezoneHelpers.applyTimezone(request.time, timeOffset)
                 if (request.requesterRole === 'STUDENT') {
                     request.requesterObj = await studentSchema.findOne({_id: request.requester})
                 } else {
@@ -265,7 +265,7 @@ router.patch('/updateScheduling/:id/:role/:timeOffset', passport.authenticate('j
                     status: status
                 }).populate('mentor')
             for (let request of dbData) {
-                request.time = await timezoneHelpers.applyTimezone(request.time, timeOffset)
+                request.time = timezoneHelpers.applyTimezone(request.time, timeOffset)
             }
             schedulings.push(dbData)
         }

--- a/server/routes/requests.js
+++ b/server/routes/requests.js
@@ -164,6 +164,38 @@ router.patch('/updateRequest/:id/:timeOffset', passport.authenticate('jwt', {ses
     }
 })
 
+router.patch('/leaveFinalNote/:id/:timeOffset', passport.authenticate('jwt', {session: false}), async (req,res, next) => {
+    let alumniId = req.params.id;
+    let timeOffset = req.params.timeOffset;
+    let requestId = req.body.requestId;
+    let finalNote = req.body.finalNote;
+    let conditions = ['Awaiting Confirmation', 'Confirmed', 'Completed']
+    let requests = []
+    try {
+        let request = await requestSchema.findById(requestId);
+        request.finalNote = finalNote
+        await request.save()
+        for (let status of conditions) {
+            const dbData = await requestSchema.find({mentor: alumniId, status: status})
+            for (let request of dbData) {
+                request.time = await timezoneHelpers.applyTimezone(request.time, timeOffset)
+                if (request.requesterRole === 'STUDENT') {
+                    request.requesterObj = await studentSchema.findOne({_id: request.requester})
+                } else {
+                    request.requesterObj = await alumniSchema.findOne({_id: request.requester})
+                }
+            }
+            requests.push(dbData)
+        }
+        res.json({'requests' : requests});
+    } catch (e) {
+        console.log('/request/leaveFinalNote Error: ' + e)
+        res.status(500).send({
+            message: 'Failed to add final note: ' + e
+        })
+    }
+})
+
 router.get('/getRequests/:id/:timeOffset', passport.authenticate('jwt', {session: false}), async (req, res, next) => {
     let alumniId = req.params.id;
     let timeOffset = parseInt(req.params.timeOffset)
@@ -243,6 +275,37 @@ router.patch('/updateScheduling/:id/:role/:timeOffset', passport.authenticate('j
         res.status(500).send({message: 'updateScheduling error: ' + e})
     }
 })
+
+router.patch('/leaveFeedback/:id/:role/:timeOffset', passport.authenticate('jwt', {session: false}), async (req, res, next) => {
+    let requesterId = req.params.id;
+    let requesterRole = req.params.role;
+    let timeOffset = parseInt(req.params.timeOffset);
+    let requestId = req.body.requestId;
+    let feedback = req.body.feedback;
+    let conditions = ['Awaiting Confirmation', 'Confirmed', 'Completed']
+    let schedulings = []
+    try {
+        let updatedScheduling = await requestSchema.findById(requestId)
+        updatedScheduling.feedback = feedback
+        await updatedScheduling.save()
+        for (let status of conditions) {
+            const dbData = await requestSchema.find({
+                    requester: requesterId,
+                    requesterRole: requesterRole,
+                    status: status
+                }).populate('mentor')
+            for (let request of dbData) {
+                request.time = await timezoneHelpers.applyTimezone(request.time, timeOffset)
+            }
+            schedulings.push(dbData)
+        }
+        res.json({'schedulings' : schedulings});
+    } catch (e) {
+        console.log('leaveFeedback error: ' + e)
+        res.status(500).send({message: 'leaveFeedback error: ' + e})
+    }
+})
+
 
 router.get('/getConfirmed/:id/:timeOffset', passport.authenticate('jwt', {session: false}), async (req, res, next) => {
     let alumniId = req.params.id;


### PR DESCRIPTION
Added a modal to requestsview (final note) and schedulingsview (feedback)
Added a button to completed cards to trigger modals
Added endpoints to update requests with feedback/final notes
Removed mark as completed from schedulings

Request/Scheduling cards will now only show populated fields (mentee note, final note, feedback)


Images:

Schedulings completed:
![image](https://user-images.githubusercontent.com/54961598/85211132-f686c780-b313-11ea-8db4-e9dcd4ce7cc3.png)

Schedulings feedback modal:
![image](https://user-images.githubusercontent.com/54961598/85211137-08686a80-b314-11ea-918e-f1211d0d9a8c.png)

Requests completed:
![image](https://user-images.githubusercontent.com/54961598/85211147-26ce6600-b314-11ea-9fe8-bb78241b53fd.png)

Requests final note modal:
![image](https://user-images.githubusercontent.com/54961598/85211153-3f3e8080-b314-11ea-8902-e161def64e78.png)

