### PR TITLE
Hides student details on private events

### DIFF
--- a/client/src/components/NewsFeed.js
+++ b/client/src/components/NewsFeed.js
@@ -156,13 +156,15 @@ export default class NewsFeed extends Component {
                     <Feed.Label>
                         <Image src={mentorDetails.imageURL} />
                     </Feed.Label>
-                    <Feed.Label>
-                        <Image src={menteeDetails.imageURL} />
-                    </Feed.Label>
+                    {menteeDetails.imageURL &&
+                        <Feed.Label>
+                            <Image src={menteeDetails.imageURL} />
+                        </Feed.Label>
+                    }
                     <Feed.Content>
                         <Feed.Summary>
                             <Modal closeIcon onClose={this.close} dimmer='blurring' trigger={
-                                <Feed.User>{mentorDetails.name} (Alumni)</Feed.User>
+                                <Feed.User>{mentorDetails.name}</Feed.User>
                             }>
                                 <Header>
                                     Details for {mentorDetails.name}
@@ -172,16 +174,23 @@ export default class NewsFeed extends Component {
                                 </Modal.Content>
                             </Modal>
                             {` confirmed a call with `}
-                            <Modal closeIcon onClose={this.close} dimmer='blurring' trigger={
-                                <Feed.User>{menteeDetails.name}</Feed.User>
-                            }>
-                                <Header>
-                                    Details for {menteeDetails.name}
-                                </Header>
-                                <Modal.Content>
-                                    <StudentProfile details={menteeDetails} isViewOnly={true} />
-                                </Modal.Content>
-                            </Modal> to discuss {feedItem.supportData && feedItem.supportData.topic}
+                            {menteeDetails.name ? (
+                                <Modal closeIcon onClose={this.close} dimmer='blurring' trigger={
+                                    <Feed.User>{menteeDetails.name}</Feed.User>
+                                }>
+                                    <Header>
+                                        Details for {menteeDetails.name}
+                                    </Header>
+                                    <Modal.Content>
+                                        <StudentProfile details={menteeDetails} isViewOnly={true} />
+                                    </Modal.Content>
+                                </Modal>
+                                ):
+                                    <>
+                                    {'a student in your grade '}
+                                    </>
+                            }
+                            {' to discuss' } {feedItem.supportData && feedItem.supportData.topic}!
                                 <Feed.Date>{feedItem.timeElapsed}</Feed.Date>
                         </Feed.Summary>
                     </Feed.Content>

--- a/server/routes/newsfeed.js
+++ b/server/routes/newsfeed.js
@@ -13,12 +13,17 @@ router.get('/getNews/:role/:id', async (req, res, next) => {
         let dbData;
         if (role == 'ALUMNI') {
             userInfo = await alumniSchema.findById(id)
-            dbData = await newsSchema.find({role: {$ne: 'STUDENT'}, school: userInfo.school}).populate('alumni').populate('students')
+            dbData = await newsSchema.find({role: {$ne: 'STUDENT'}, school: userInfo.school})
+                .populate('alumni').populate('students')
         } else {
             userInfo = await studentSchema.findById(id)
-            dbData = await newsSchema.find({role: {$ne: 'ALUMNI'}, school: userInfo.school, grade: {$in: [null, userInfo.grade]}}).populate('alumni').populate('students')
+            dbData = await newsSchema.find({role: {$ne: 'ALUMNI'}, school: userInfo.school, grade: {$in: [null, userInfo.grade]}})
+                .populate('alumni').populate('students')
         }
         let objData = dbData.map(item => {
+            if (role === 'STUDENT' && item.event === 'Confirmed Meeting') {
+                item.depopulate('students') 
+            }
             let itemObj = item.toObject()
             itemObj.timeElapsed = moment(item.dateCreated).fromNow()
             return itemObj


### PR DESCRIPTION
News Feed will now hide student information for confirmed calls, but will allow other students to see that they have joined the platform

Alumni will be able to see the student (This can be changed by simply not populating students for alumni fetches if this is undesirable behavior)

Student View
<img width="984" alt="Screen Shot 2020-06-27 at 10 45 35 PM" src="https://user-images.githubusercontent.com/54961598/85936401-81ddfb00-b8c8-11ea-9632-d5907175fe17.png">

Alumni View
<img width="1183" alt="Screen Shot 2020-06-27 at 10 44 10 PM" src="https://user-images.githubusercontent.com/54961598/85936403-899d9f80-b8c8-11ea-9325-0a64ec6a1cf3.png">

