### PR TITLE
removed email field from alumni and student objects

### DIFF
--- a/client/src/components/RequestModal.js
+++ b/client/src/components/RequestModal.js
@@ -231,9 +231,7 @@ export default class RequestModal extends Component {
                         onClick={this.submitRequest}
                         disabled={
                                 ((this.state.topicValue === '' || 
-                                this.state.availabilityValue === '') &&
-                                (this.state.topicValue === '' ||
-                                this.state.note === ''))
+                                this.state.availabilityValue === ''))
                             }
                     >
                         Submit Request

--- a/server/models/alumniSchema.js
+++ b/server/models/alumniSchema.js
@@ -22,7 +22,7 @@ const alumniSchema = new Schema(
   {
     imageURL: {type: String, default:'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png'},
     name: {type: String, required: true},
-    email: {type: String, reguired: true, unique: true},
+    user: {type: Schema.Types.ObjectId, ref: 'User', required: true},
     gradYear: {type: Number, required: true},
     country: {type: String, enum: COUNTRIES, required: true},
     city: {type: String, required: true},

--- a/server/models/studentSchema.js
+++ b/server/models/studentSchema.js
@@ -6,7 +6,7 @@ const studentSchema = new Schema(
   {
     imageURL: {type: String, default:'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png'},
     name: {type: String, required: true},
-    email: {type: String, required: true},
+    user: {type: Schema.Types.ObjectId, ref: 'User', required: true},
     grade: {type: Number, required: true},
     //requests: [{type: Schema.Types.ObjectId, ref: 'requestSchema'}]
     //issuesLiked: [{type: Schema.Types.ObjectId, ref: 'issueSchema'}]

--- a/server/routes/alumni.js
+++ b/server/routes/alumni.js
@@ -148,10 +148,22 @@ router.post('/', async (req, res, next) => {
         const approved = false
         const verificationToken = crypto({length: 16});
         var passwordHash = await bcrypt.hash(password, HASH_COST)
+
+        const user_instance = new userSchema(
+            {
+              email: email,
+              passwordHash: passwordHash,
+              verificationToken: verificationToken,
+              role: role,
+              emailVerified: emailVerified,
+              approved: approved
+            }
+        );
+        await user_instance.save();
         var alumni_instance = new alumniSchema(
             {
                 name: name,
-                email: email,
+                user: user_instance._id,
                 gradYear: gradYear,
                 country: country,
                 city: city,
@@ -174,18 +186,7 @@ router.post('/', async (req, res, next) => {
                 topics: topics,
             }
         )
-        const user_instance = new userSchema(
-            {
-              email: email,
-              passwordHash: passwordHash,
-              verificationToken: verificationToken,
-              role: role,
-              emailVerified: emailVerified,
-              approved: approved
-            }
-        );
         await alumni_instance.save();
-        await user_instance.save();
         const news_instance = new newsSchema({
             event: 'New Alumni',
             alumni: [alumni_instance._id],

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -55,7 +55,7 @@ router.post('/login', (req, res, next) => {
           try {
             let userRole = user.role && user.role.toUpperCase()
             if (userRole === "ALUMNI") {
-              const alumni = await alumniSchema.findOne({email: user.email});
+              const alumni = await alumniSchema.findOne({user: user._id})
               payload.id = alumni._id
               const cookie = jwt.sign(JSON.stringify(payload), JWT_SECRET);
               // set jwt-signed cookie on response
@@ -68,7 +68,7 @@ router.post('/login', (req, res, next) => {
                 }
               );
             } else if (userRole === "STUDENT") {
-              const student = await studentSchema.findOne({email: user.email});
+              const student = await studentSchema.findOne({user: user._id});
               payload.id = student._id
               const cookie = jwt.sign(JSON.stringify(payload), JWT_SECRET);
               // set jwt-signed cookie on response

--- a/server/routes/requests.js
+++ b/server/routes/requests.js
@@ -64,8 +64,8 @@ router.post('/addRequest', passport.authenticate('jwt', {session: false}), async
             id: time[0].id
         })
         let insert = await request_instance.save();
-        let mentor = await alumniSchema.findOne({_id: mentorId}, {email: 1})
-        await sendNewRequestEmail(mentor.email)
+        let mentor = await alumniSchema.findOne({_id: mentorId}).populate('user')
+        await sendNewRequestEmail(mentor.user.email)
         res.status(200).send({
             message: 'Successfully added request',
             request: request_instance
@@ -90,8 +90,8 @@ router.patch('/updateRequest/:id/:timeOffset', passport.authenticate('jwt', {ses
         request.status = newStatus
         await request.save()
         if (newStatus === 'Confirmed') {
-            let mentee = await studentSchema.findOne({_id: request.student})
-            let mentor = await alumniSchema.findOne({_id: alumniId})
+            let mentee = await studentSchema.findOne({_id: request.student}).populate('user')
+            let mentor = await alumniSchema.findOne({_id: alumniId}).populate('user')
             let menteeTime = timezoneHelpers.applyTimezone(request.time, mentee.timeZone)
             let menteeTimeString = `${menteeTime[0].day} ${timezoneHelpers.getSlot(menteeTime[0].time)}`
             // javascript directory mutates time object, so we need to strip timezone here before using time again again
@@ -119,10 +119,10 @@ router.patch('/updateRequest/:id/:timeOffset', passport.authenticate('jwt', {ses
             await news_instance.save();
 
             await sendRequestConfirmedEmail(
-                mentee.email,
+                mentee.user.email,
                 mentee.name, 
                 menteeTimeString,
-                mentor.email,
+                mentor.user.email,
                 mentor.name,
                 mentorTimeString,
                 request.topic

--- a/server/routes/students.js
+++ b/server/routes/students.js
@@ -36,19 +36,6 @@ router.post('/', async (req, res, next) => {
         var passwordHash = await bcrypt.hash(password, HASH_COST)
         // find schoolLogo
         let school = await schoolSchema.findOne({_id: schoolId})
-        var student_instance = new studentSchema(
-            {
-                name: name,
-                email: email,
-                grade: grade,
-                // requests: [{type: Schema.Types.ObjectId, ref: 'requestSchema'}]
-                // issuesLiked: [{type: Schema.Types.ObjectId, ref: 'issueSchema'}]
-                school: schoolId,
-                timeZone: -timeZone,
-                schoolLogo: school.logoURL,
-                imageURL: imageURL
-            }
-        )
         const user_instance = new userSchema(
             {
               email: email,
@@ -59,9 +46,22 @@ router.post('/', async (req, res, next) => {
               approved: approved
             }
         );
-        
-        await student_instance.save();
         await user_instance.save();
+        
+        var student_instance = new studentSchema(
+            {
+                name: name,
+                user: user_instance._id,
+                grade: grade,
+                // requests: [{type: Schema.Types.ObjectId, ref: 'requestSchema'}]
+                // issuesLiked: [{type: Schema.Types.ObjectId, ref: 'issueSchema'}]
+                school: schoolId,
+                timeZone: -timeZone,
+                schoolLogo: school.logoURL,
+                imageURL: imageURL
+            }
+        )      
+        await student_instance.save();
         const news_instance = new newsSchema(
             {
                 event: 'New Student',


### PR DESCRIPTION
Note: This PR makes significant changes to the student and alumni schema.
After merging this PR, do the following in shell to ensure that mongoose will not throw errors:
~$ mongo
mongo shell: $ use ofi-testdata
mongo shell: $ db.dropDatabase()
mongo shell: $ exit

then, assuming you're using homebrew, restart your mongo drivers by doing:
~$ brew services stop mongodb-community
~$ brew services start mongodb-community
To ensure that the local mongodb instance fully restarts. This has the added benefit of not having to frequently restart mongodb, as it will instead start on machine startup in the future.

This will resolve any E11000 errors caused by mongoose anticipating an email field in alumni/students

This has been successfully tested on features with email integration such as requests and signup
Note: for security reasons, user routes should probably be deleted - however, this warrants further discussion