### PR TITLE
admin creation and route setup

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -22,6 +22,7 @@ import * as actions from './redux/actions'
 
 export const ALUMNI = "ALUMNI"
 export const STUDENT = "STUDENT"
+export const ADMIN = "ADMIN"
 
 /*
   STORE SETUP
@@ -126,6 +127,37 @@ var alumniNavBarItems = (approved) => {
   return navBarItems;
 }
 
+var adminNavBarItems = () => {
+  let navBarItems = [
+    {
+        id: 'data',
+        name: 'Data Management',
+        navLink: '/'
+    },
+    {
+        id: 'students',
+        name: 'Students',
+        navLink: '/students'
+    },
+    {
+        id: 'alumni',
+        name: 'Alumni',
+        navLink: '/alumni'
+    },
+    {
+        id: 'colleges',
+        name: 'Colleges',
+        navLink: '/colleges'
+    },
+    {
+        id: 'schools',
+        name: 'Schools',
+        navLink: '/schools'
+    }
+  ]
+  return navBarItems;
+}
+
 const studentNavBarItems = (isModerator) => {
   let navBarItems = [
     {
@@ -176,6 +208,7 @@ class App extends Component {
     this.renderScreens = this.renderScreens.bind(this);
     this.renderLoggedInRoutes = this.renderLoggedInRoutes.bind(this);
     this.refreshProfile = this.refreshProfile.bind(this);
+    this.liftRole = this.liftRole.bind(this);
   }
 
   async componentWillMount() {
@@ -195,9 +228,9 @@ class App extends Component {
         const parsedJWT = JSON.parse(atob(jwtVal.split('.')[1]));
         role = parsedJWT.role;
         id = parsedJWT.id;
-        profile = await this.fetchProfile(role, id);
+        profile = await this.fetchProfile(role[0], id);
         this.setState({
-          role: role,
+          role: role[0],
           userDetails: profile,
           approved: profile.approved,
           loggedIn: true
@@ -253,6 +286,12 @@ class App extends Component {
         userDetails: details.userToSend
       });
       window.location.reload()
+  }
+
+  liftRole(role) {
+    this.setState({
+      role: role
+    })
   }
 
   renderLoggedInRoutes(role) {
@@ -471,6 +510,86 @@ class App extends Component {
           />
           </>
         )
+      case ADMIN:
+        return (
+          <>
+          <Route exact path={`/`} render={(props) => 
+                  this.state.loggedIn ?
+                  <>
+                      <Navbar
+                          userDetails={this.state.userDetails}
+                          role={role}
+                          timezoneActive={true}
+                          navItems={adminNavBarItems()}
+                          activeItem={'data'}
+                      />
+                      <p>Data Management</p>
+                  </> :
+                  <Redirect to={"/login"}/>
+              }
+          />
+          <Route exact path={`/students`} render={(props) => 
+                  this.state.loggedIn ?
+                  <>
+                      <Navbar
+                          userDetails={this.state.userDetails}
+                          role={role}
+                          timezoneActive={true}
+                          navItems={adminNavBarItems()}
+                          activeItem={'students'}
+                      />
+                      <p>Students</p>
+                  </> :
+                    <Redirect to={"/login"}/>
+                }
+          />
+          <Route exact path={`/alumni`} render={(props) => 
+                  this.state.loggedIn ?
+                  <>
+                      <Navbar
+                          userDetails={this.state.userDetails}
+                          role={role}
+                          timezoneActive={true}
+                          navItems={adminNavBarItems()}
+                          activeItem={'alumni'}
+                      />
+                      <p>Alumni</p>
+                  </> :
+                  <Redirect to={"/login"}/>
+              }
+          />
+          <Route exact path={`/colleges`} render={(props) => 
+                  this.state.loggedIn ?
+                  <>
+                      <Navbar
+                          userDetails={this.state.userDetails}
+                          role={role}
+                          timezoneActive={true}
+                          navItems={adminNavBarItems()}
+                          activeItem={'colleges'}
+                      />
+                      <p>Colleges</p>
+                  </> :
+                  <Redirect to={"/login"}/>
+              }
+          />
+          <Route exact path={`/schools`} render={(props) => 
+                  this.state.loggedIn ?
+                  <>
+                      <Navbar
+                          userDetails={this.state.userDetails}
+                          role={role}
+                          timezoneActive={true}
+                          navItems={adminNavBarItems()}
+                          activeItem={'schools'}
+                      />
+                      <p>Schools</p>
+                  </> :
+                  <Redirect to={"/login"}/>
+              }
+          />
+        </>
+        )
       default:
         return (
           <Route exact path={`/`} render={(props) => 
@@ -559,6 +678,9 @@ class App extends Component {
               logout={this.logout}
               email={this.state.userDetails && this.state.userDetails.email}
               schoolLogo={this.state.userDetails && this.state.userDetails.schoolLogo}
+              userId={this.state.userDetails && this.state.userDetails.user}
+              role={this.state.role}
+              liftRole={this.liftRole}
             />
             <Container>
               {this.renderScreens(this.state.role)}

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -241,7 +241,8 @@ export default class Header extends Component {
     }
 
     renderLogo() {
-        let imageLink = this.props.loggedIn ? this.props.schoolLogo : require('./logo.png')
+        let imageLink = this.props.loggedIn && this.state.currRole !== 'ADMIN' ? 
+            this.props.schoolLogo : require('./logo.png');
         return (
                 <Image centered src={imageLink} size='small'/>                
         )

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -255,6 +255,7 @@ export default class Header extends Component {
             <>
                 <Label basic >Current Role:
                     <Dropdown
+                        compact
                         style={{'marginLeft': '5px'}}
                         selection
                         options={this.state.availableRoles}
@@ -270,11 +271,12 @@ export default class Header extends Component {
     }
 
     changeRole = (e, { value }) => {
-        this.setState({ currRole: value })
-        this.props.liftRole(value)
+        this.setState({ currRole: value }, () => {
+            this.props.liftRole(value)
+        })
     }
 
-    fetchUser() {
+    async fetchUser() {
         return makeCall({}, '/user/one/' + this.state.userId, 'get');
     }
 

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import {Grid, Button, Modal, Form, Image, Label} from 'semantic-ui-react';
+import {Grid, Button, Modal, Form, Image, Label, Dropdown} from 'semantic-ui-react';
 import { Link } from "react-router-dom"
 import 'semantic-ui-css/semantic.min.css';
 import swal from "sweetalert";
@@ -26,7 +26,10 @@ export default class Header extends Component {
             confirmPassword: '',
             sendingPasswordRequest: false,
             modalOpen: false,
-            passwordsMatching: true
+            passwordsMatching: true,
+            currRole: this.props.role,
+            userId: this.props.userId,
+            availableRoles: []
         }
         this.renderLoginStateInfo = this.renderLoginStateInfo.bind(this);
         this.sendNewPasswordRequest = this.sendNewPasswordRequest.bind(this);
@@ -35,6 +38,17 @@ export default class Header extends Component {
         this.handleChange = this.handleChange.bind(this);
         this.handlePasswordChange = this.handlePasswordChange.bind(this);
         this.comparePasswords = this.comparePasswords.bind(this);
+        this.renderRoleDropdown = this.renderRoleDropdown.bind(this);
+    }
+
+    async componentDidUpdate(prevProps) {
+        if (prevProps.role !== this.props.role && prevProps.userId !== this.props.userId) {
+            await this.setState({
+                currRole: this.props.role,
+                userId: this.props.userId
+            })
+            await this.fetchRoles()
+        }
     }
 
     comparePasswords() {
@@ -217,8 +231,7 @@ export default class Header extends Component {
             </Link>
         </>
         return (
-        <Grid.Column 
-            style ={{margin: '30px 0 0 0'}}
+        <Grid.Column
             width = {6}
         >
             {this.props.loggedIn ?
@@ -233,6 +246,54 @@ export default class Header extends Component {
                 <Image centered src={imageLink} size='small'/>                
         )
     }
+
+    renderRoleDropdown() {
+        return(
+            <div>
+            {this.state.availableRoles.length > 1 && 
+            <>
+                <Label basic >Current Role:
+                    <Dropdown
+                        style={{'marginLeft': '5px'}}
+                        selection
+                        options={this.state.availableRoles}
+                        value={this.state.currRole}
+                        onChange={this.changeRole.bind(this)}
+                    />
+                </Label>
+                
+            </>
+            }
+            </div>
+        )
+    }
+
+    changeRole = (e, { value }) => {
+        this.setState({ currRole: value })
+        this.props.liftRole(value)
+    }
+
+    fetchUser() {
+        return makeCall({}, '/user/one/' + this.state.userId, 'get');
+    }
+
+    async fetchRoles() {
+        if (this.state.userId) {
+            let availableRoles = []
+            let userInfo = null
+            userInfo = await this.fetchUser()
+            availableRoles = userInfo.result.role.map(role => {
+                role = role.toLowerCase()
+                return {
+                    key: role,
+                    text: role.charAt(0).toUpperCase() + role.slice(1),
+                    value: role.toUpperCase()
+                }
+            })
+            this.setState({availableRoles: availableRoles})
+        }
+    }
+
     render () {
         return (
             <Grid 
@@ -242,15 +303,19 @@ export default class Header extends Component {
                 columns={3}
                 centered
             >
-                <Grid.Column width={5}>
-                    <div></div>
-                </Grid.Column>
-                <Grid.Column width={6}>
-                    {this.renderLogo()}
-                </Grid.Column>
-                <Grid.Column width={5}>
-                    {this.renderLoginStateInfo()}
-                </Grid.Column>
+                <Grid.Row columns={"equal"}>
+                    <Grid.Column width={5} textAlign='right' verticalAlign='middle'>
+                        {this.props.loggedIn &&
+                            this.renderRoleDropdown()
+                        }
+                    </Grid.Column>
+                    <Grid.Column width={6}>
+                        {this.renderLogo()}
+                    </Grid.Column>
+                    <Grid.Column width={5} verticalAlign='middle'>
+                        {this.renderLoginStateInfo()}
+                    </Grid.Column>
+                </Grid.Row>
             </Grid>
         )
     }

--- a/server/models/userSchema.js
+++ b/server/models/userSchema.js
@@ -8,7 +8,7 @@ const userSchema = new Schema(
     passwordHash: {type: String, required: true},
     verificationToken: {type: String, required: true},
     passwordChangeToken: {type: String, required: false},
-    role: {type: String, required: true},
+    role: [{type: String, required: true, enum: ['ALUMNI', 'STUDENT', 'ADMIN']}],
     emailVerified: {type: Boolean, required: true}
   }
 );

--- a/server/routes/alumni.js
+++ b/server/routes/alumni.js
@@ -143,7 +143,7 @@ router.post('/', async (req, res, next) => {
 
         // find schoolLogo
         let school = await schoolSchema.findOne({_id: schoolId})
-        const role = "ALUMNI"
+        const role = ["ALUMNI"]
         const emailVerified = false
         const approved = false
         const verificationToken = crypto({length: 16});

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -53,8 +53,10 @@ router.post('/login', (req, res, next) => {
             return next(error);
           }
           try {
-            let userRole = user.role && user.role.toUpperCase()
-            if (userRole === "ALUMNI") {
+            let userRole = user.role && user.role.map(role => {
+              return role.toUpperCase()
+            })
+            if (userRole[0] === "ALUMNI") {
               const alumni = await alumniSchema.findOne({user: user._id})
               payload.id = alumni._id
               const cookie = jwt.sign(JSON.stringify(payload), JWT_SECRET);
@@ -67,7 +69,7 @@ router.post('/login', (req, res, next) => {
                   details: alumni
                 }
               );
-            } else if (userRole === "STUDENT") {
+            } else if (userRole[0] === "STUDENT") {
               const student = await studentSchema.findOne({user: user._id});
               payload.id = student._id
               const cookie = jwt.sign(JSON.stringify(payload), JWT_SECRET);

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -56,7 +56,7 @@ router.post('/login', (req, res, next) => {
             let userRole = user.role && user.role.map(role => {
               return role.toUpperCase()
             })
-            if (userRole[0] === "ALUMNI") {
+            if (userRole.includes("ALUMNI")) {
               const alumni = await alumniSchema.findOne({user: user._id})
               payload.id = alumni._id
               const cookie = jwt.sign(JSON.stringify(payload), JWT_SECRET);
@@ -69,7 +69,7 @@ router.post('/login', (req, res, next) => {
                   details: alumni
                 }
               );
-            } else if (userRole[0] === "STUDENT") {
+            } else if (userRole.includes("STUDENT")) {
               const student = await studentSchema.findOne({user: user._id});
               payload.id = student._id
               const cookie = jwt.sign(JSON.stringify(payload), JWT_SECRET);

--- a/server/routes/students.js
+++ b/server/routes/students.js
@@ -29,7 +29,7 @@ router.post('/', async (req, res, next) => {
         const imageURL = req.body.imageURL;
         // TODO: need to add timeZone in frontend request
         const timeZone = req.body.timeZone;
-        const role = "STUDENT"
+        const role = ["STUDENT"]
         const emailVerified = false
         const approved = false
         const verificationToken = crypto({length: 16});

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -4,9 +4,10 @@ var router = express.Router();
 var userSchema = require('../models/userSchema');
 require('mongoose').Promise = global.Promise
 
-router.get('/:id', passport.authenticate('jwt', {session: false}), async (req, res, next) => {
+router.get('/one/:id', passport.authenticate('jwt', {session: false}), async (req, res, next) => {
     try {
         const dbData = await userSchema.findOne({_id: req.params.id})
+        dbData.email = undefined;
         res.json({'result' : dbData});
     } catch (e) {
         console.log("Error: util#oneUser", e);

--- a/server/routes/utilMongoose.js
+++ b/server/routes/utilMongoose.js
@@ -66,7 +66,8 @@ const createAlumni = async (_email, _name, _country, _city, _profession, _compan
     const password = MOCK_PASSWORD;
     const availabilities = []
 
-    const role = "ALUMNI"
+    let role = ["ALUMNI"];
+    if ((Math.random() * 10 + 1) >= 5) role.push("ADMIN");
     const emailVerified = false
     const approved = false
     const verificationToken = crypto({length: 16});
@@ -116,7 +117,7 @@ const createStudent = async (_email, _name, _picLink, timezone, _school, _school
     const grade = Math.floor((Math.random() * 10) + 2);
     const password = MOCK_PASSWORD;
 
-    const role = "STUDENT"
+    const role = ["STUDENT"]
     const emailVerified = false
     const approved = false
     const verificationToken = crypto({length: 16});


### PR DESCRIPTION
user.role is now an array
Users can switch between roles using a dropdown if more than one is available:  
<img width="879" alt="Screen Shot 2020-07-09 at 1 17 58 PM" src="https://user-images.githubusercontent.com/54961598/87070649-190b5280-c1e7-11ea-9e69-6c6e502c9a0d.png">

Currently defaults to Alumni/Student view first, though this relies upon the order of the array in mongodb

Placeholder admin routes now available
Since this represented a major change to the database, updating may cause E11000 errors from mongodb - use PR #66 for reference.

There are likely a couple of bugs introduced with this update - from what I could tell, every component was still working because they receive role as a prop, but since role is now an array there may be a couple of problems in higher level components