### PR TITLE
Student/Alumni are awarded footyPoints when users they referred sign up

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -25,6 +25,7 @@ import * as actions from './redux/actions'
 import Polls from './components/admin_dashboard/Polls';
 import Footer from './components/Footer'
 import LandingPage from './landingPageContent/LandingPage';
+import ReferralLinkGenerator from './ReferralLinkGenerator';
 
 export const ALUMNI = "ALUMNI"
 export const STUDENT = "STUDENT"
@@ -459,6 +460,11 @@ class App extends Component {
                           timezoneActive={true}
                           navItems={alumniNavBarItems(this.state.approved, this.state.newRequestsCount, this.state.unseenMessagesCount)}
                           activeItem={'home'}
+                      />
+                      <ReferralLinkGenerator
+                        schoolId={this.state.userDetails.school._id}
+                        schoolName={this.state.userDetails.school.name}
+                        userId={this.state.userDetails.user}
                       />
                       <NewsFeed
                         userDetails={this.state.userDetails}
@@ -969,7 +975,18 @@ class App extends Component {
                   this.state.loggedIn ? <Redirect to={"/"}/> : 
                   <Signup
                       isAlumni={true}
-                      match={props}
+                      match={props.match}
+                      history={props.history}
+                  />
+              }
+          />
+          <Route exact path={`/register/alumni/:referrerId/:schoolId`} render={
+              (props) =>
+                  this.state.loggedIn ? <Redirect to={"/"}/> : 
+                  <Signup
+                      isAlumni={true}
+                      match={props.match}
+                      history={props.history}
                   />
               }
           />
@@ -977,9 +994,20 @@ class App extends Component {
               (props) => 
                 this.state.loggedIn ? <Redirect to={"/"}/> :
                 <Signup
-                      isAlumni={false}
-                      match={props}
-                  />
+                  isAlumni={false}
+                  match={props.match}
+                  history={props.history}
+                />
+              }
+          />
+          <Route exact path={`/register/student/:referrerId/:schoolId`} render={
+              (props) => 
+              this.state.loggedIn ? <Redirect to={"/"}/> :
+                <Signup
+                    isAlumni={false}
+                    match={props.match}
+                    history={props.history}
+                />
               }
           />
           <Route exact path={"/login"} render={(props) =>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -26,6 +26,7 @@ import Polls from './components/admin_dashboard/Polls';
 import Footer from './components/Footer'
 import LandingPage from './landingPageContent/LandingPage';
 import ReferralLinkGenerator from './ReferralLinkGenerator';
+import { SemanticToastContainer } from 'react-semantic-toasts'
 
 export const ALUMNI = "ALUMNI"
 export const STUDENT = "STUDENT"
@@ -1060,6 +1061,7 @@ class App extends Component {
                 currentRole={this.state.role}
               />
               <Container>
+                <SemanticToastContainer position="top-right"/>
                 {this.renderScreens(this.state.role)}
               </Container>
               <Footer/>

--- a/client/src/ReferralLinkGenerator.js
+++ b/client/src/ReferralLinkGenerator.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Card, Button } from 'semantic-ui-react'
+
+/**
+ * Button group that allows a user to copy a referral link to share
+ * @param {*} props
+ * schoolId - id for the user current school
+ * schoolName - name of the user school
+ * userId - userId for the student / alumnus 
+ */
+export default function ReferralLinkGenerator (props) {
+
+    const copyLink = (role) => {
+        let referralLink = `${window.location.href}register/${role}/${props.userId}/${props.schoolId}`
+        navigator.clipboard.writeText(referralLink)
+    }
+
+    return (
+        <Card
+            centered
+            fluid
+        >
+            <Card.Content>
+                <Card.Description>
+                Earn <strong>FootyPoints</strong> by bringing more users from {props.schoolName} to our network
+                </Card.Description>
+            </Card.Content>
+            <Card.Content extra>
+                <div className='ui two buttons'>
+                <Button
+                    id='alumni-referral-link'
+                    basic
+                    color='orange'
+                    onClick={copyLink('alumni')}
+                >
+                    Refer Alumni
+                </Button>
+                <Button
+                    basic
+                    color='yellow'
+                    onClick={copyLink('student')}
+                >
+                    Refer Student
+                </Button>
+                </div>
+            </Card.Content>
+        </Card>
+    )
+}

--- a/client/src/ReferralLinkGenerator.js
+++ b/client/src/ReferralLinkGenerator.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Card, Button } from 'semantic-ui-react'
+import { toast } from 'react-semantic-toasts'
 
 /**
  * Button group that allows a user to copy a referral link to share
@@ -12,7 +13,17 @@ export default function ReferralLinkGenerator (props) {
 
     const copyLink = (role) => {
         let referralLink = `${window.location.href}register/${role}/${props.userId}/${props.schoolId}`
-        navigator.clipboard.writeText(referralLink)
+        navigator.clipboard.writeText(referralLink).then(() => {
+            toast(
+                {
+                    title: 'Referral Link Copied',
+                    description: <p>Your {role.toUpperCase()} referral link has been copied to clipboard!</p>,
+                    color: role === 'alumni' ? 'orange' : 'yellow',
+                    time: 2000,
+                    icon: 'paper plane',
+                }
+            );
+        })
     }
 
     return (
@@ -28,17 +39,16 @@ export default function ReferralLinkGenerator (props) {
             <Card.Content extra>
                 <div className='ui two buttons'>
                 <Button
-                    id='alumni-referral-link'
                     basic
                     color='orange'
-                    onClick={copyLink('alumni')}
+                    onClick={() => copyLink('alumni')}
                 >
                     Refer Alumni
                 </Button>
                 <Button
                     basic
                     color='yellow'
-                    onClick={copyLink('student')}
+                    onClick={() => copyLink('student')}
                 >
                     Refer Student
                 </Button>

--- a/client/src/components/Signup.js
+++ b/client/src/components/Signup.js
@@ -96,7 +96,8 @@ export default class Signup extends React.Component {
             imageModalOpen: false,
             termsModalOpen: false,
             userAgreedTerms: false,
-            error: ''
+            error: '',
+            referrerId: '' // mongoId for referrer
         }
 
         this.handleChange = this.handleChange.bind(this);
@@ -438,6 +439,15 @@ export default class Signup extends React.Component {
     }
 
     async UNSAFE_componentWillMount() {
+        let referrerId = this.props.match.params && this.props.match.params.referrerId
+        let schoolId = this.props.match.params && this.props.match.params.schoolId
+        if (referrerId && schoolId) {
+            this.setState({
+                referrerId
+            }, () => {
+                this.handleSchoolSelection(null, {value: schoolId})
+            })
+        }
         let result = await makeCall(null, '/drop/schoolsOptions', 'get')
         let topicOptions = await makeCall(null, `/alumni/topicOptions`, 'get')
         this.setState({
@@ -460,8 +470,12 @@ export default class Signup extends React.Component {
         })
     }
 
+    /**
+     * Handles school selection for sign up form submission
+     * @param {*} e React Event object
+     * @param {*} value the mongoId of the school selected either via dropdown or obtained as url param from referral link 
+     */
     handleSchoolSelection(e, {value}) {
-        e.preventDefault()
         this.setState({schoolSelection : value})
     }
 
@@ -723,7 +737,8 @@ export default class Signup extends React.Component {
                 password: this.state.password,
                 timeZone: ((new Date().getTimezoneOffset())*100)/60, // getTimezoneOffset fetches offset in minutes
                 schoolId: this.state.schoolSelection,
-                imageURL: this.state.imageUrl
+                imageURL: this.state.imageUrl,
+                referrerId: this.state.referrerId // empty for when a signup happens without referral
             }
             if (!this.props.isAlumni) {
                 payload = Object.assign({}, payload, {
@@ -777,7 +792,7 @@ export default class Signup extends React.Component {
                             text: "Your submission was successful! Please check your email to confirm your account.",
                             icon: "success",
                         }).then(() => 
-                            this.props.match.history.push('/login')
+                            this.props.history.push('/login')
                         );
                     })
                     
@@ -801,7 +816,7 @@ export default class Signup extends React.Component {
 
     goBack(e) {
         e.preventDefault();
-        this.props.match.history.goBack();
+        this.props.history.goBack();
     }
 
     render() {
@@ -869,7 +884,7 @@ export default class Signup extends React.Component {
                             search
                             selection
                             options={this.state.schoolOptions}
-                            value={this.state.value}
+                            value={this.state.schoolSelection}
                             onChange={this.handleSchoolSelection}
                         >
                         </Form.Dropdown>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1503,6 +1503,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "react-semantic-toasts": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/react-semantic-toasts/-/react-semantic-toasts-0.6.5.tgz",
+      "integrity": "sha512-XsSvlix69XbzXkT728sRx9TnP7c7g8rGf31KS37Hf/DQLEuAJzsUwqHmo70Q6u7tIcWbCF58UnCzg9mNlYlijA=="
+    },
     "read-pkg": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-4.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
-    "pure-react-carousel": "^1.27.6"
+    "pure-react-carousel": "^1.27.6",
+    "react-semantic-toasts": "^0.6.5"
   },
   "devDependencies": {
     "concurrently": "^4.0.1",

--- a/server/footyPointsChart.js
+++ b/server/footyPointsChart.js
@@ -1,0 +1,4 @@
+module.exports.FOOTY_POINTS_CHART = {
+    alumniAddsOpportunity: 8,
+    userBringsInNewMemberByReferral: 10
+}

--- a/server/routes/alumni.js
+++ b/server/routes/alumni.js
@@ -20,6 +20,7 @@ const opportunitySchema = require('../models/opportunitySchema');
 var sendAlumniVerificationEmail = require('../routes/helpers/emailHelpers').sendAlumniVerificationEmail;
 const { ObjectId } = require('mongodb');
 require('mongoose').Promise = global.Promise
+var FOOTY_POINTS_CHART = require('../footyPointsChart').FOOTY_POINTS_CHART
 
 const HASH_COST = 10;
 
@@ -35,7 +36,7 @@ const awardReferralPoints = async (referrerId) => {
     } else {
         referringProfile = await studentSchema.findOne({user: referringUser})
     }
-    referringProfile.footyPoints += 10 // TODO: create footyPoints chart
+    referringProfile.footyPoints += FOOTY_POINTS_CHART.userBringsInNewMemberByReferral
     await referringProfile.save()
 }
 
@@ -651,7 +652,7 @@ router.post('/opportunity/:id', passport.authenticate('jwt', {session: false}), 
         })
         await newOpportunity.save()
         alumni.opportunities.push(newOpportunity)
-        alumni.footyPoints += 8;
+        alumni.footyPoints += FOOTY_POINTS_CHART.alumniAddsOpportunity;
         await alumni.save()
         // do not wait on finishing request
         queueOpportunities(alumni, newOpportunity)

--- a/server/routes/alumni.js
+++ b/server/routes/alumni.js
@@ -24,6 +24,22 @@ require('mongoose').Promise = global.Promise
 const HASH_COST = 10;
 
 /**
+ * Finds the alumnus or student account by the id of the referrer provided and awards footyPoints
+ * @param {*} referrerId 
+ */
+const awardReferralPoints = async (referrerId) => {
+    let referringUser = await userSchema.findById(referrerId);
+    let referringProfile
+    if (referringUser.role.includes("ALUMNI")) {
+        referringProfile = await alumniSchema.find({user: referringUser})
+    } else {
+        referringProfile = await studentSchema.find({user: referringUser})
+    }
+    referringProfile.footyPoints += 10 // TODO: create footyPoints chart
+    referringProfile.save()
+}
+
+/**
  * Prevents users from accidentally creating an existing item as a custom new entry
  * @param {String} newItem 
  * @param {MongooseSchema} schema 
@@ -75,6 +91,9 @@ const getUniqueInterests = (allInterests) => {
     return uniqueInterests
 }
 
+/**
+ * Sign ups a new alumnus
+ */
 router.post('/', async (req, res, next) => {
     try {
         const email = req.body.email;
@@ -172,6 +191,12 @@ router.post('/', async (req, res, next) => {
         const verificationToken = crypto({length: 16});
         const emailSubscriptionToken = crypto({length: 16});
         var passwordHash = await bcrypt.hash(password, HASH_COST)
+
+        // check if the user has been referred
+        const referrerId = req.body.referrerId;
+        if (referrerId) {
+            await awardReferralPoints(referrerId)
+        }
 
         const user_instance = new userSchema(
             {
@@ -723,3 +748,4 @@ router.get('/newRequestsCount/:alumniId', passport.authenticate('jwt', {session:
 module.exports = router;
 module.exports.generateNewAndExistingInterests = generateNewAndExistingInterests
 module.exports.getUniqueInterests = getUniqueInterests
+module.exports.awardReferralPoints = awardReferralPoints

--- a/server/routes/alumni.js
+++ b/server/routes/alumni.js
@@ -31,12 +31,12 @@ const awardReferralPoints = async (referrerId) => {
     let referringUser = await userSchema.findById(referrerId);
     let referringProfile
     if (referringUser.role.includes("ALUMNI")) {
-        referringProfile = await alumniSchema.find({user: referringUser})
+        referringProfile = await alumniSchema.findOne({user: referringUser})
     } else {
-        referringProfile = await studentSchema.find({user: referringUser})
+        referringProfile = await studentSchema.findOne({user: referringUser})
     }
     referringProfile.footyPoints += 10 // TODO: create footyPoints chart
-    referringProfile.save()
+    await referringProfile.save()
 }
 
 /**

--- a/server/routes/students.js
+++ b/server/routes/students.js
@@ -11,6 +11,7 @@ var requestSchema = require('../models/requestSchema');
 var sendStudentVerificationEmail = require('../routes/helpers/emailHelpers').sendStudentVerificationEmail
 var generateNewAndExistingInterests = require("./alumni").generateNewAndExistingInterests
 var getUniqueInterests = require("./alumni").getUniqueInterests
+var awardReferralPoints = require("./alumni").awardReferralPoints
 require('mongoose').Promise = global.Promise
 
 var logger = require("../logging")
@@ -56,6 +57,13 @@ router.post('/', async (req, res, next) => {
         var passwordHash = await bcrypt.hash(password, HASH_COST)
         // find schoolLogo
         let school = await schoolSchema.findOne({_id: schoolId})
+
+        // check if the user has been referred
+        const referrerId = req.body.referrerId;
+        if (referrerId) {
+            await awardReferralPoints(referrerId)
+        }
+
         const user_instance = new userSchema(
             {
               email: email,

--- a/server/routes/students.js
+++ b/server/routes/students.js
@@ -110,7 +110,7 @@ router.post('/', async (req, res, next) => {
             student: student_instance
         });
     } catch (e) {
-        logger.error(`POST | action=student/ | email=${email} | error=${e}`)
+        logger.error(`POST | action=student/ | email=${req.body.email} | error=${e}`)
         res.status(500).send({
             message: 'Failed adding student: ' + e
         });

--- a/server/tests/routes/alumni.test.js
+++ b/server/tests/routes/alumni.test.js
@@ -1,0 +1,145 @@
+const mongoose = require("mongoose")
+const createServer = require("../testingTools")
+const request = require('supertest');
+var userSchema = require('../../models/userSchema');
+var schoolSchema = require('../../models/schoolSchema');
+var alumniSchema = require('../../models/alumniSchema');
+var studentSchema = require('../../models/studentSchema');
+const majorSchema = require("../../models/majorSchema");
+const collegeSchema = require("../../models/collegeSchema");
+
+
+const app = createServer();
+
+const MOCK_S3_IMAGE = "some_image_link"
+
+beforeAll(async (done) => {
+    process.env.NODE_ENV = 'test';
+    mongoose.connect("mongodb://localhost:27017/test-test", { useNewUrlParser: true });
+    await request(app).get('/util/seed/');
+    done()
+});
+
+afterAll(async () => {
+    const collections = Object.keys(mongoose.connection.collections);
+    for (const collectionName of collections) {
+        const collection = mongoose.connection.collections[collectionName];
+        await collection.deleteMany();
+    }
+    await mongoose.connection.close();
+    delete process.env.NODE_ENV
+});
+
+test('sign up alumnus without referral', async () => {
+    const dummyEmail = "dummy@alumni.com"
+    const someRandomSchool = await schoolSchema.findOne()
+    const someRandomMajor = await majorSchema.findOne()
+    const someRandomCollege = await collegeSchema.findOne()
+    const res = await request(app).post(`/alumni/`).send({
+        city: "Best City",
+        collegeCountry: "Antigua and Barbuda",
+        country: "Albania",
+        email: dummyEmail,
+        existingCollegeId: someRandomCollege._id,
+        existingCompanyId: "",
+        existingInterests: [],
+        existingJobTitleId: "",
+        existingMajorId: someRandomMajor._id,
+        graduationYear: "2014",
+        imageURL: MOCK_S3_IMAGE,
+        name: "Dummy Alum",
+        newCollege: "",
+        newCompany: "",
+        newInterests: [],
+        newJobTitle: "",
+        newMajor: "",
+        password: "pass",
+        referrerId: "",
+        schoolId: someRandomSchool._id,
+        timeZone: 500,
+        topics: [],
+        zoomLink: ""
+    });
+    expect(res.status).toEqual(200);
+    const user = await userSchema.findOne({email: dummyEmail});
+    expect(!!user)
+    expect(!user.approved)
+})
+
+test('sign up alumnus via alumni referral', async () => {
+    const dummyEmail = "dummy1@alumni.com"
+    const someRandomSchool = await schoolSchema.findOne()
+    const someRandomMajor = await majorSchema.findOne()
+    const someRandomCollege = await collegeSchema.findOne()
+    const referringUser = await userSchema.findOne({role: {$in: ["ALUMNI"]}})
+    const res = await request(app).post(`/alumni/`).send({
+        city: "Best City",
+        collegeCountry: "Antigua and Barbuda",
+        country: "Albania",
+        email: dummyEmail,
+        existingCollegeId: someRandomCollege._id,
+        existingCompanyId: "",
+        existingInterests: [],
+        existingJobTitleId: "",
+        existingMajorId: someRandomMajor._id,
+        graduationYear: "2014",
+        imageURL: MOCK_S3_IMAGE,
+        name: "Dummy Alum",
+        newCollege: "",
+        newCompany: "",
+        newInterests: [],
+        newJobTitle: "",
+        newMajor: "",
+        password: "pass",
+        referrerId: referringUser._id,
+        schoolId: someRandomSchool._id,
+        timeZone: 500,
+        topics: [],
+        zoomLink: ""
+    });
+    expect(res.status).toEqual(200);
+    const user = await userSchema.findOne({email: dummyEmail});
+    expect(!!user)
+    expect(!user.approved)
+    const referringAlumni = await alumniSchema.findOne({user: referringUser})
+    expect(referringAlumni.footyPoints).toEqual(10);
+})
+
+test('sign up alumnus via student referral', async () => {
+    const dummyEmail = "dummy2@alumni.com"
+    const someRandomSchool = await schoolSchema.findOne()
+    const someRandomMajor = await majorSchema.findOne()
+    const someRandomCollege = await collegeSchema.findOne()
+    const referringUser = await userSchema.findOne({role: {$in: ["STUDENT"]}})
+    const res = await request(app).post(`/alumni/`).send({
+        city: "Best City",
+        collegeCountry: "Antigua and Barbuda",
+        country: "Albania",
+        email: dummyEmail,
+        existingCollegeId: someRandomCollege._id,
+        existingCompanyId: "",
+        existingInterests: [],
+        existingJobTitleId: "",
+        existingMajorId: someRandomMajor._id,
+        graduationYear: "2014",
+        imageURL: MOCK_S3_IMAGE,
+        name: "Dummy Alum",
+        newCollege: "",
+        newCompany: "",
+        newInterests: [],
+        newJobTitle: "",
+        newMajor: "",
+        password: "pass",
+        referrerId: referringUser._id,
+        schoolId: someRandomSchool._id,
+        timeZone: 500,
+        topics: [],
+        zoomLink: ""
+    });
+    expect(res.status).toEqual(200);
+    const user = await userSchema.findOne({email: dummyEmail});
+    expect(!!user)
+    expect(!user.approved)
+    const referringStudent = await studentSchema.findOne({user: referringUser})
+    expect(referringStudent.footyPoints).toEqual(10);
+})

--- a/server/tests/routes/students.test.js
+++ b/server/tests/routes/students.test.js
@@ -1,0 +1,92 @@
+const mongoose = require("mongoose")
+const createServer = require("../testingTools")
+const request = require('supertest');
+var userSchema = require('../../models/userSchema');
+var schoolSchema = require('../../models/schoolSchema');
+var alumniSchema = require('../../models/alumniSchema');
+var studentSchema = require('../../models/studentSchema');
+
+
+const app = createServer();
+
+const MOCK_S3_IMAGE = "some_image_link"
+
+beforeAll(async (done) => {
+    process.env.NODE_ENV = 'test';
+    mongoose.connect("mongodb://localhost:27017/test-test", { useNewUrlParser: true });
+    await request(app).get('/util/seed/');
+    done()
+});
+
+afterAll(async () => {
+    const collections = Object.keys(mongoose.connection.collections);
+    for (const collectionName of collections) {
+        const collection = mongoose.connection.collections[collectionName];
+        await collection.deleteMany();
+    }
+    await mongoose.connection.close();
+    delete process.env.NODE_ENV
+});
+
+test('sign up student without referral', async () => {
+    const dummyEmail = "dummy@student.com"
+    const someRandomSchool = await schoolSchema.findOne()
+    const res = await request(app).post(`/student/`).send({
+        email: dummyEmail,
+        grade: 11,
+        imageURL: MOCK_S3_IMAGE,
+        name: "Dummy",
+        password: "pass",
+        referrerId: "",
+        schoolId: someRandomSchool._id,
+        timeZone: 500
+    });
+    expect(res.status).toEqual(200);
+    const user = await userSchema.findOne({email: dummyEmail});
+    expect(!!user)
+    expect(!user.approved)
+})
+
+test('sign up student via alumni referral', async () => {
+    const dummyEmail = "dummy1@student.com"
+    const someRandomSchool = await schoolSchema.findOne()
+    const referringUser = await userSchema.findOne({role: {$in: ["ALUMNI"]}})
+    const res = await request(app).post(`/student/`).send({
+        email: dummyEmail,
+        grade: 11,
+        imageURL: MOCK_S3_IMAGE,
+        name: "Dummy",
+        password: "pass",
+        referrerId: referringUser._id,
+        schoolId: someRandomSchool._id,
+        timeZone: 500
+    });
+    expect(res.status).toEqual(200);
+    const user = await userSchema.findOne({email: dummyEmail});
+    expect(!!user)
+    expect(!user.approved)
+    const referringAlumni = await alumniSchema.findOne({user: referringUser})
+    expect(referringAlumni.footyPoints).toEqual(10);
+})
+
+test('sign up student via student referral', async () => {
+    const dummyEmail = "dummy2@student.com"
+    const someRandomSchool = await schoolSchema.findOne()
+    const referringUser = await userSchema.findOne({role: {$in: ["STUDENT"]}})
+    const res = await request(app).post(`/student/`).send({
+        email: dummyEmail,
+        grade: 11,
+        imageURL: MOCK_S3_IMAGE,
+        name: "Dummy",
+        password: "pass",
+        referrerId: referringUser._id,
+        schoolId: someRandomSchool._id,
+        timeZone: 500
+    });
+    expect(res.status).toEqual(200);
+    const user = await userSchema.findOne({email: dummyEmail});
+    expect(!!user)
+    expect(!user.approved)
+    const referringStudent = await studentSchema.findOne({user: referringUser})
+    expect(referringStudent.footyPoints).toEqual(10);
+})

--- a/server/tests/testingTools.js
+++ b/server/tests/testingTools.js
@@ -1,6 +1,7 @@
 const express = require("express");
 var indexRouter = require('../routes/index');
 var alumniRouter = require('../routes/alumni');
+var studentRouter = require('../routes/students');
 var mongooseUtilRouter = require('../routes/utilMongoose');
 
 
@@ -16,6 +17,7 @@ function createServer() {
     app.use(express.json());
     app.use('/', indexRouter);
     app.use('/alumni/', alumniRouter);
+    app.use('/student/', studentRouter);
     app.use('/util/', mongooseUtilRouter);
 	return app;
 }


### PR DESCRIPTION
Alumni and students can now copy a personalized referral link that students and alumni from their own school can use to sign up. The referring alumnus/student is awarded 10 footyPoints on sign up.

Bonus:
- We have React toasts that can be used through the app

Screens:
![image](https://user-images.githubusercontent.com/31665569/109906143-e9292780-7c6d-11eb-91ec-e8caff8ecbaf.png)
Custom referral links Front and center


Toast to hint that link is copied to clipboard (See in action on test.onefootin.org)

![image](https://user-images.githubusercontent.com/31665569/109906201-11b12180-7c6e-11eb-80cd-99623d77b6d7.png)
Custom link pre-populates school and takes the user to relevant role's sign up page

Manual Testing steps:

* Sign in as a student/alumnus
* Generate a personalized referral link for a student
* Confirm you see the toast and the link is copied to clipboard
* Confirm you are brought to student registration page with the correct school already prepopulated
* Confirm you can sign up
* Repeat for generating link for alumnus


